### PR TITLE
Disable discovery on single node clusters

### DIFF
--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -6,10 +6,10 @@ network.host: ["_local_","_site_"]
 discovery.seed_hosts: [ {% for host in groups['elasticsearch']  %}
 "{{ hostvars[host].ansible_default_ipv4.address | default(hostvars[host].ansible_all_ipv4_addresses[0]) }}"{% if not loop.last %},{% endif %}
 {% endfor %} ]
+{% endif %}
 cluster.initial_master_nodes: [ {% for host in groups['elasticsearch']  %}
 "{{ hostvars[host].ansible_hostname }}"{% if not loop.last %},{% endif %}
 {% endfor %} ]
-{% endif %}
 {% if elastic_temperature is defined %}
 node.attr.temp: "{{ elastic_temperature }}"
 {% endif %}

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -2,12 +2,14 @@ node.name: "{{ ansible_hostname }}"
 path.data: {{ elasticsearch_datapath }}
 path.logs: /var/log/elasticsearch
 network.host: ["_local_","_site_"]
+{% if elastic_release < 8 or groups['elasticsearch'] | length > 1 %}
 discovery.seed_hosts: [ {% for host in groups['elasticsearch']  %}
 "{{ hostvars[host].ansible_default_ipv4.address | default(hostvars[host].ansible_all_ipv4_addresses[0]) }}"{% if not loop.last %},{% endif %}
 {% endfor %} ]
 cluster.initial_master_nodes: [ {% for host in groups['elasticsearch']  %}
 "{{ hostvars[host].ansible_hostname }}"{% if not loop.last %},{% endif %}
 {% endfor %} ]
+{% endif %}
 {% if elastic_temperature is defined %}
 node.attr.temp: "{{ elastic_temperature }}"
 {% endif %}


### PR DESCRIPTION
fixes #8

Wir need to remove these lines to suppress repeating warnings about redundant configuration. But only on single node clusters of Elasticsearch 8.x and up. Elasticsearch 7 seems to still need it. Multi node clusters need it in any case.