### PR TITLE
Add Syslog to default Filebeat path configuration, for non-RHEL8 systems

### DIFF
--- a/roles/beats/defaults/main.yml
+++ b/roles/beats/defaults/main.yml
@@ -33,6 +33,7 @@ filebeat_log_inputs:
     name: messages
     paths:
       - /var/log/messages
+      - /var/log/syslog
 filebeat_enable: true
 filebeat_journald: false
 filebeat_journald_inputs:


### PR DESCRIPTION
Non-Rhel8 Systems use  different default paths in Filebeat:
- /var/log/syslog

This PR adds this, so data is directly visible in Kibana.

Fixes #18