### PR TITLE
Change galaxy installation to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This collection installs and manages the Elastic Stack. It provides roles every 
 You can easily install the collection with the ansible-galaxy command.
 
 ```
-ansible-galaxy collection install netways.elasticstack
+ansible-galaxy collection install https://github.com/netways/ansible-collection-elasticstack.git
 ```
 
 Or if you are using Tower or AWX add the collection to your requirements file.


### PR DESCRIPTION
fixes #24 

As long as the collection is not available via Ansible Galaxy we need to show how to install it from GitHub.