### PR TITLE
Make sure all certificates contain used hostnames

### DIFF
--- a/roles/beats/tasks/beats-security.yml
+++ b/roles/beats/tasks/beats-security.yml
@@ -19,8 +19,8 @@
     --ca {{ elastic_ca_dir }}/elastic-stack-ca.p12
     --ca-pass {{ elastic_ca_pass }}
     --name {{ ansible_hostname }}
-    --ip {{ ansible_default_ipv4.address }}
-    --dns {{ ansible_hostname }},{{ ansible_fqdn }}
+    --ip {{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}
+    --dns {{ ansible_hostname }},{{ ansible_fqdn }},{{ inventory_hostname }}
     --pass {{ beats_tls_key_passphrase }}
     --pem
     --out {{ elastic_ca_dir }}/{{ ansible_hostname }}-beats.zip

--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -192,7 +192,7 @@
         --ca-pass {{ elastic_ca_pass }}
         --name {{ hostvars[item].ansible_hostname }}
         --ip {{ hostvars[item].ansible_default_ipv4.address | default(hostvars[item].ansible_all_ipv4_addresses[0]) }}
-        --dns {{ hostvars[item].ansible_hostname }},{{ hostvars[item].ansible_fqdn }}
+        --dns {{ hostvars[item].ansible_hostname }},{{ hostvars[item].ansible_fqdn }},{{ hostvars[item].inventory_hostname }}
         --pass {{ elasticsearch_tls_key_passphrase }}
         --out {{ elastic_ca_dir }}/{{ hostvars[item].ansible_hostname }}.p12
       loop: "{{ groups['elasticsearch'] }}"

--- a/roles/kibana/tasks/kibana-security.yml
+++ b/roles/kibana/tasks/kibana-security.yml
@@ -56,8 +56,8 @@
     --ca {{ elastic_ca_dir }}/elastic-stack-ca.p12
     --ca-pass {{ elastic_ca_pass }}
     --name {{ ansible_hostname }}
-    --ip {{ ansible_default_ipv4.address }}
-    --dns {{ ansible_hostname }},{{ ansible_fqdn }}
+    --ip {{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}
+    --dns {{ ansible_hostname }},{{ ansible_fqdn }},{{ inventory_hostname }}
     --pass {{ kibana_tls_key_passphrase }}
     --out {{ elastic_ca_dir }}/{{ ansible_hostname }}.p12
   delegate_to: "{{ elasticsearch_ca }}"

--- a/roles/logstash/tasks/logstash-security.yml
+++ b/roles/logstash/tasks/logstash-security.yml
@@ -24,7 +24,7 @@
     --ca {{ elastic_ca_dir }}/elastic-stack-ca.p12
     --ca-pass {{ elastic_ca_pass }}
     --name {{ ansible_hostname }}
-    --ip {{ ansible_default_ipv4.address }}
+    --ip {{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}
     --dns {{ ansible_hostname }},{{ ansible_fqdn }},{{ inventory_hostname }}
     --pass {{ logstash_tls_key_passphrase }}
     --out {{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.p12


### PR DESCRIPTION
fixes #14
needs #27 fixed to work

* Use same set of `ip`/`dns` combo for all certificates
* Add `inventory_hostname` to SAN of all certificates