### PR TITLE
Wiper Role For Faster Test Purging 

### DIFF
--- a/roles/logstash/vars/main.yml
+++ b/roles/logstash/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for logstash
+logstash_elasticsearch: "10.77.15.13"

--- a/roles/nelwiper/README.md
+++ b/roles/nelwiper/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/nelwiper/defaults/main.yml
+++ b/roles/nelwiper/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for elastic-repos
+elastic_release: 7
+elastic_variant: elastic
+
+elastic_rpm_workaround: false
+

--- a/roles/nelwiper/handlers/main.yml
+++ b/roles/nelwiper/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for nel-wiper

--- a/roles/nelwiper/meta/main.yml
+++ b/roles/nelwiper/meta/main.yml
@@ -1,0 +1,33 @@
+galaxy_info:
+  role_name: elastic_repos
+  namespace: netways
+  description: Elastic Repositories
+  author: Thomas Widhalm <thomas.widhalm@netways.de>
+  company: Netways GmbH
+  license: GPL-3.0-or-later
+
+  min_ansible_version: "2.9"
+  platforms:
+  - name: EL
+    versions:
+    - "7"
+    - "8"
+    - "9"
+  - name: Debian
+    versions:
+    - buster
+    - bullseye
+  - name: opensuse
+    versions:
+    - "15.2"
+  - name: Ubuntu
+    versions:
+    - focal
+    - jammy
+
+  galaxy_tags:
+    - logmanagement
+    - elasticstack
+
+dependencies: []
+

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -16,6 +16,7 @@
 #  register: package_check
 #  when: ansible_facts['os_family'] == "Debian"
 - name: Stop Belk Services
+  ignore_errors: true
   service:
     name: "{{ item }}"
     state: restarted

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -6,6 +6,9 @@
     update_cache: yes
     force_apt_get: yes
 
+-name: Resets all units with failed status
+  shell:
+    cmd: systemctl reset-failed
 #- name: "Check if listed package is installed or not on Debian Linux family"
 #  command: dpkg-query -l "{{ item }}"
 #  with_items:

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -29,28 +29,28 @@
   when: ansible_facts['os_family'] == "Debian"
 
 ## start kill pids if running
-- name: Get running processes list from remote host
-  ignore_errors: yes
-  shell: "ps -few | grep logstash | awk '{print $2}'"
-  register: running_processes
-
-- name: Kill running processes
-  ignore_errors: yes
-  shell: "kill {{ item }}"
-  with_items: "{{ running_processes.stdout_lines }}"
-
-- wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-  with_items: "{{ running_processes.stdout_lines }}"
-  ignore_errors: yes
-  register: processes_name
-
-- name: Force kill stuck processes
-  ignore_errors: yes
-  shell: "kill -9 {{ item }}"
-  with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
-
+#- name: Get running processes list from remote host
+#  ignore_errors: yes
+#  shell: "ps -few | grep logstash | awk '{print $2}'"
+#  register: running_processes
+#
+#- name: Kill running processes
+#  ignore_errors: yes
+#  shell: "kill {{ item }}"
+#  with_items: "{{ running_processes.stdout_lines }}"
+#
+#- wait_for:
+#    path: "/proc/{{ item }}/status"
+#    state: absent
+#  with_items: "{{ running_processes.stdout_lines }}"
+#  ignore_errors: yes
+#  register: processes_name
+#
+#- name: Force kill stuck processes
+#  ignore_errors: yes
+#  shell: "kill -9 {{ item }}"
+#  with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
+#
 ## end kill pids if running
 
 # start purging

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -6,15 +6,15 @@
     update_cache: yes
     force_apt_get: yes
 
-- name: "Check if listed package is installed or not on Debian Linux family"
-  command: dpkg-query -l "{{ item }}"
-  with_items:
-    - filebeat
-    - elasticsearch
-    - logstash
-    - kibana
-  register: package_check
-  when: ansible_facts['os_family'] == "Debian"
+#- name: "Check if listed package is installed or not on Debian Linux family"
+#  command: dpkg-query -l "{{ item }}"
+#  with_items:
+#    - filebeat
+#    - elasticsearch
+#    - logstash
+#    - kibana
+#  register: package_check
+#  when: ansible_facts['os_family'] == "Debian"
 
 - name: Remove apt lock file
   file:
@@ -57,14 +57,14 @@
 - name: Debian, Ubuntu Remove the entire elastic stack
   apt:
     autoremove: yes 
-    update_cache: yes
+    #update_cache: yes
     name:
     - filebeat
     - kibana
     - elasticsearch
     - logstash
     state: absent
-  when: package_check is not failed and ansible_facts['os_family']  == 'Debian'  
+  when: ansible_facts['os_family']  == 'Debian'  
 
 
 # clean directories
@@ -84,7 +84,7 @@
     - kibana
     - filebeat
 
-- name: Remove leftover /etc/$name
+- name: Remove leftover /etc/$package
   file:
     path: /etc/{{ item }}
     state: absent
@@ -94,7 +94,7 @@
     - kibana
     - filebeat
 
-- name: Remove leftover /var/$lib
+- name: Remove leftover /var/lib/$package
   file:
     path: /var/lib/{{ item }}
     state: absent
@@ -104,7 +104,7 @@
     - kibana
     - filebeat
 
-- name: Remove leftover /var/log
+- name: Remove leftover /var/log/$package
   file:
     path: /var/log/{{item}}
     state: absent
@@ -113,6 +113,15 @@
     - elasticsearch
     - kibana
     - filebeat
+
+## Wipe all leftover dependencies
+- name: Warning, Potentially uncomment, Wipe all everything with left dependencies over
+  shell:
+    cmd: dpkg -l | grep '^rc' | awk '{print $2}' | xargs sudo apt-get purge --yes
+
+- name: Reload unit Files
+  shell:
+    cmd: systemctl daemon-reload
 #- name: Apt for sure
 #  apt: name=foobar state=installed
 #  register: apt_status

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -147,3 +147,4 @@
 #  register: out
 #
 #
+# add this: sudo dpkg --configure -a

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -1,0 +1,123 @@
+---
+# https://techviewleo.com/ansible-check-if-software-package-is-installed/
+# https://crunchify.com/ansible-how-to-grep-ps-few-and-kill-process-running-on-remote-host/
+- name: Update APT Cache
+  apt:
+    update_cache: yes
+    force_apt_get: yes
+
+- name: "Check if listed package is installed or not on Debian Linux family"
+  command: dpkg-query -l "{{ item }}"
+  with_items:
+    - filebeat
+    - elasticsearch
+    - logstash
+    - kibana
+  register: package_check
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Remove apt lock file
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items: 
+    - /var/lib/dpkg/lock
+    - /var/lib/dpkg/lock
+    - /var/lib/dpkg/lock-frontend
+    - /var/lib/apt/lists/lock
+    - /var/cache/apt/archives/lock
+  when: ansible_facts['os_family'] == "Debian"
+
+## start kill pids if running
+- name: Get running processes list from remote host
+  ignore_errors: yes
+  shell: "ps -few | grep logstash | awk '{print $2}'"
+  register: running_processes
+
+- name: Kill running processes
+  ignore_errors: yes
+  shell: "kill {{ item }}"
+  with_items: "{{ running_processes.stdout_lines }}"
+
+- wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ running_processes.stdout_lines }}"
+  ignore_errors: yes
+  register: processes_name
+
+- name: Force kill stuck processes
+  ignore_errors: yes
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
+
+## end kill pids if running
+
+- name: Debian, Ubuntu Remove the entire elastic stack
+  apt:
+    autoremove: yes 
+    update_cache: yes
+    name:
+    - filebeat
+    - kibana
+    - elasticsearch
+    - logstash
+    state: absent
+  when: package_check is not failed and ansible_facts['os_family']  == 'Debian'  
+
+
+- name: Remove leftover /usr/share/$name
+  file:
+    path: /usr/share/{{ item }}
+    state: absent
+  with_items:
+    - logstash
+    - elasticsearch
+    - kibana
+    - filebeat
+
+- name: Remove leftover /etc/$name
+  file:
+    path: /etc/{{ item }}
+    state: absent
+  with_items:
+    - logstash
+    - elasticsearch
+    - kibana
+    - filebeat
+
+- name: Remove leftover /etc/$name
+  file:
+    path: /var/lib/{{ item }}
+    state: absent
+  with_items:
+    - logstash
+    - elasticsearch
+    - kibana
+    - filebeat
+
+#- name: Apt for sure
+#  apt: name=foobar state=installed
+#  register: apt_status
+#  # 2018 syntax:
+#  # until: apt_status|success
+#  # 2020 syntax:
+#  until: apt_status is success
+#  delay: 2
+#  retries: 2
+
+# name: store all of the files and directories in the /tmp directory that contain 'foo' in the 'out' variable
+#  find:
+#    paths:
+#      - /etc/
+#      - /usr/share
+#      - /var/lib
+#    patterns: 
+#      - (?i).logstash*
+#      - (?i).elasticsearch*
+#      - (?i).kibana*
+#      - (?i).filebeat*
+#    use_regex: true
+#  register: out
+#
+#

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -19,10 +19,10 @@
   ignore_errors: true
   service:
     name: "{{ item }}"
-    state: restarted
+    state: stopped
   with_items:
     - elasticsearch
-    - logstash
+   # - logstash
     - filebeat
     - kibana
 
@@ -56,10 +56,19 @@
   ignore_errors: yes
   register: processes_name
 
-- name: Fallback kill Logstash again
+- name: 1/2 Fallback Logstash Kill
   ignore_errors: yes
   shell: "kill -9 {{ item }}"
   with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
+
+- name: Install lsof to kill Logstash
+  ansible.builtin.apt:
+    name: lsof
+    state: present
+
+- name: 2/2 Fallback Logstash Kill
+  shell:
+    cmd: kill -9 `lsof -t -u logstash`
 
 ## End Logstash 
 

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -53,6 +53,7 @@
 
 ## end kill pids if running
 
+# start purging
 - name: Debian, Ubuntu Remove the entire elastic stack
   apt:
     autoremove: yes 
@@ -66,6 +67,13 @@
   when: package_check is not failed and ansible_facts['os_family']  == 'Debian'  
 
 
+# clean directories
+- name: Remove leftover /opt/es-ca
+  file:
+    path: /opt/es-ca
+    state: absent
+
+# clean directories
 - name: Remove leftover /usr/share/$name
   file:
     path: /usr/share/{{ item }}
@@ -86,7 +94,7 @@
     - kibana
     - filebeat
 
-- name: Remove leftover /etc/$name
+- name: Remove leftover /var/$lib
   file:
     path: /var/lib/{{ item }}
     state: absent
@@ -96,6 +104,15 @@
     - kibana
     - filebeat
 
+- name: Remove leftover /var/log
+  file:
+    path: /var/log/{{item}}
+    state: absent
+  with_items:
+    - logstash
+    - elasticsearch
+    - kibana
+    - filebeat
 #- name: Apt for sure
 #  apt: name=foobar state=installed
 #  register: apt_status

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -15,6 +15,15 @@
 #    - kibana
 #  register: package_check
 #  when: ansible_facts['os_family'] == "Debian"
+- name: Stop Belk Services
+  service:
+    name: "{{ item }}"
+    state: restarted
+  with_items:
+    - elasticsearch
+    - logstash
+    - filebeat
+    - kibana
 
 - name: Remove apt lock file
   file:
@@ -28,30 +37,30 @@
     - /var/cache/apt/archives/lock
   when: ansible_facts['os_family'] == "Debian"
 
-## start kill pids if running
-#- name: Get running processes list from remote host
-#  ignore_errors: yes
-#  shell: "ps -few | grep logstash | awk '{print $2}'"
-#  register: running_processes
-#
-#- name: Kill running processes
-#  ignore_errors: yes
-#  shell: "kill {{ item }}"
-#  with_items: "{{ running_processes.stdout_lines }}"
-#
-#- wait_for:
-#    path: "/proc/{{ item }}/status"
-#    state: absent
-#  with_items: "{{ running_processes.stdout_lines }}"
-#  ignore_errors: yes
-#  register: processes_name
-#
-#- name: Force kill stuck processes
-#  ignore_errors: yes
-#  shell: "kill -9 {{ item }}"
-#  with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
-#
-## end kill pids if running
+# Start Logstash Elimination
+- name: Find Logstash PID
+  ignore_errors: yes
+  shell: "ps -few | grep logstash | awk '{print $2}'"
+  register: running_processes
+
+- name: Kill Logstash
+  ignore_errors: yes
+  shell: "kill {{ item }}"
+  with_items: "{{ running_processes.stdout_lines }}"
+
+- wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ running_processes.stdout_lines }}"
+  ignore_errors: yes
+  register: processes_name
+
+- name: Fallback kill Logstash again
+  ignore_errors: yes
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
+
+## End Logstash 
 
 # start purging
 - name: Debian, Ubuntu Remove the entire elastic stack
@@ -147,4 +156,10 @@
 #  register: out
 #
 #
-# add this: sudo dpkg --configure -a
+- name: Reconfigure dpkg
+  shell:
+    cmd: systemctl daemon-reload
+
+- name: apt update && apt upgade
+  shell:
+    cmd: apt update -y && apt upgrade -y

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -62,11 +62,13 @@
   with_items: "{{ process_name.results | select('failed') | map(attribute='item') | list }}"
 
 - name: Install lsof to kill Logstash
+  ignore_errors: yes
   ansible.builtin.apt:
     name: lsof
     state: present
 
 - name: 2/2 Fallback Logstash Kill
+  ignore_errors: yes
   shell:
     cmd: kill -9 `lsof -t -u logstash`
 

--- a/roles/nelwiper/tasks/debian.yml
+++ b/roles/nelwiper/tasks/debian.yml
@@ -6,9 +6,9 @@
     update_cache: yes
     force_apt_get: yes
 
--name: Resets all units with failed status
+- name: Resets all units with failed status
   shell:
-    cmd: systemctl reset-failed
+   cmd: systemctl reset-failed
 #- name: "Check if listed package is installed or not on Debian Linux family"
 #  command: dpkg-query -l "{{ item }}"
 #  with_items:

--- a/roles/nelwiper/tasks/main.yml
+++ b/roles/nelwiper/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Check for versions
+  ansible.builtin.fail:
+    msg: "No OSS versions later than 7 are available"
+  when:
+    - elastic_release > 7
+    - elastic_variant == "oss"
+
+- import_tasks: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- import_tasks: debian.yml
+  when: ansible_os_family == 'Debian'
+
+- import_tasks: suse.yml
+  when: ansible_os_family|lower == 'suse'

--- a/roles/nelwiper/tasks/redhat.yml
+++ b/roles/nelwiper/tasks/redhat.yml
@@ -1,0 +1,13 @@
+---
+
+#- name: Remove the entire Elastic stack
+#  yum:
+#    name: "{{item}}" 
+#    state: absent
+#  with_items:
+#    - filebeat
+#    - kibana
+#    - elasticsearch
+#    - logstash
+#  when: ansible_os_family == 'RedHat'  
+#

--- a/roles/nelwiper/tasks/suse.yml
+++ b/roles/nelwiper/tasks/suse.yml
@@ -1,0 +1,12 @@
+---
+#
+#- name: Remove the entire elastic stack
+#  zypper: 
+#    name: "{{item}}" 
+#    state: absent
+#  with_items:
+#    - filebeat
+#    - kibana
+#    - elasticsearch
+#    - logstash
+#  when: ansible_os_family|lower == "suse"

--- a/roles/nelwiper/tests/inventory
+++ b/roles/nelwiper/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/nelwiper/tests/test.yml
+++ b/roles/nelwiper/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - nelwiper

--- a/roles/nelwiper/vars/main.yml
+++ b/roles/nelwiper/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for nel-wiper


### PR DESCRIPTION
Very quick & dirty, can be improved:

- This one works for Debian Systems according to first tests, I'll try to add Suse and RHEL.
- Quickly enable the role of nelwiper (neways elastic wiper), puring the main packages, stopping processes, and removing directories for the project.
- Goal: Quicker Testing and Rebuilding

---
I am just sharing the PR so far as a Preview