### PR TITLE
Add note about hardcoded host groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ collections:
 Our default configuration will collect filesystem logs placed by `rsyslog`. Therefor our example playbook makes sure, `rsyslog` is installed. If you don't want that, please change the configuration of the `beats` module. Without syslog you won't receive any messages with the default configuration.
 
 There are some comments in the Playbook. Either fill them with the correct values (`remote_user`) or consider them as a hint to commonly used options.
+
+_Note_: The roles rely on hardcoded group names for placing services on hosts. Please make sure you have groups named `elasticsearch`, `logstash` and `kibana` in your Ansible inventory. Hosts in these groups will get the respective services. Restricting your plays to the appropriate hosts will not work because the roles interact with hosts from other groups e.g. for certificate generation.
+
 ```
 ---
 - hosts: all


### PR DESCRIPTION
fixes #31

This is just a note about the collection needing certain group names in the inventory. If you can come up with something better - please change it.