### PR TITLE
This PR adds 2 possible Variants on Cleanup on the Controller

### DIFF
--- a/roles/kibana/tasks/kibana-security.yml
+++ b/roles/kibana/tasks/kibana-security.yml
@@ -111,3 +111,40 @@
     Restart Kibana
   tags:
     - certificates
+
+# Version 1 with Globbing, Find and File
+
+# Cleanup ca.crt
+- name: Controller tmp cleanup of CA
+  connection: local
+  become: no
+  file:
+    path: /tmp/ca.crt
+    state: absent
+
+# Cleanup .p12 & .crt
+- name: Controller Directory Cleanup - Find & local p12 & zip without Ansible_Hostname
+  connection: local
+  become: no  
+  find:
+    paths: /tmp
+    use_regex: yes
+    patterns:
+      - .*\.(p12|zip)$
+  register: find_p12_zip
+
+- name: delete local p12
+  connection: local
+  become: no
+  file:
+    path: "{{ item['path'] }}"
+    state: absent
+  with_items: "{{ find_p12_zip['files'] }}"
+
+# Version 2 with Shell
+
+- name: Controller Directory Cleanup - Shell removes & has the Ansible_Hostname
+#  connection: local
+#  become: no 
+#  shell:
+#    cmd: rm /tmp/{{ ansible_hostname }}* && rm /tmp/ca.crt


### PR DESCRIPTION
This PR adds 2 possible Variants on Cleanup on the Controller for Stripping Secrets o
ff the /tmp directory.

1) matches .p12 & .crt in the /tmp directory without ansible_hostname
2) shell one matches the ansible_hostname."

- It is possible 1) has a very easy way to add the "ansible hostname" I haven't found.
- This PR adds into the kiba-asecurity.yml on the very end, where all the certificates have been shared, because *kibana* is expectedly on the end of the ´elasticsearch.yml´ playbook.

Ideas for Optimizations:
1) Adapt Ansible Hostname into solution Number 1
2) Create an own task file, such as `controller-cleanup.yml` in the very last role to get triggered, or allow users to switch when the cleanup will happen, themselves, via a variable.

Issues #35 