### PR TITLE
Add rpm based checks for full stack

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         distro:
           - ubuntu2204
+          - rockylinux8
         scenario:
           - elasticstack_default
 


### PR DESCRIPTION
fixes #15

This add's checks with Rocky Linux 8 but only for the full stack. This should be a matching compromise between testing the whole stack with deb and rpm but not running every single check twice.