### PR TITLE
Fix combination of oss and release version

### DIFF
--- a/molecule/elasticstack_default/converge.yml
+++ b/molecule/elasticstack_default/converge.yml
@@ -6,8 +6,6 @@
   vars:
     elasticsearch_jna_workaround: true
     elasticsearch_disable_systemcallfilterchecks: true
-    elastic_stack_full_stack: true
-    elastic_variant: oss
     elastic_release: "{{ lookup('env', 'ELASTIC_RELEASE') | int}}"
   tasks:
     - name: Include Elastic Repos

--- a/molecule/repos_oss/converge.yml
+++ b/molecule/repos_oss/converge.yml
@@ -8,7 +8,7 @@
   vars:
     elastic_variant: oss
     elastic_rpm_workaround: true
-    elastic_release: "{{ lookup('env', 'ELASTIC_RELEASE') | int}}"
+    elastic_release: 7
   tasks:
     - name: "Include Elastic Repos"
       ansible.builtin.include_role:


### PR DESCRIPTION
There is no `oss` version of Elastic Stack after version 7.x. So we need to make sure we don't run tests for variants that don't even exist.

That can mean to pin tests to a certain release. Meaning we run the same test twice which is a bit of a waste of ressources but will only be neccessary as long as 7.x is supported. Or changing the variant to `elastic` where appropriate.