### PR TITLE
Fix verify for new Kibana API

### DIFF
--- a/molecule/kibana_full_stack/verify.yml
+++ b/molecule/kibana_full_stack/verify.yml
@@ -29,8 +29,8 @@
       command: "curl -s -u elastic:{{ elastic_password.stdout }} http://{{ ansible_hostname }}:5601/api/status"
       register: curl_out
       failed_when:
-        - '"state": "green"' not in curl_out.stdout
-        - '"summary": "Elasticsearch is available"' not in curl_out.stdout
+        - "'"state": "green"' not in curl_out.stdout"
+        - "'"summary": "Elasticsearch is available"' not in curl_out.stdout"
     when: "'kibana' in group_names"
   # The following might be nicer but doesn't work
   #- name: Connect to Kibana

--- a/molecule/kibana_full_stack/verify.yml
+++ b/molecule/kibana_full_stack/verify.yml
@@ -28,7 +28,9 @@
     - name: Connect to Kibana
       command: "curl -s -u elastic:{{ elastic_password.stdout }} http://{{ ansible_hostname }}:5601/api/status"
       register: curl_out
-      failed_when: "'green' not in curl_out.stdout"
+      failed_when:
+        - '"state": "green"' not in curl_out.stdout
+        - '"summary": "Elasticsearch is available"' not in curl_out.stdout
     when: "'kibana' in group_names"
   # The following might be nicer but doesn't work
   #- name: Connect to Kibana


### PR DESCRIPTION
fixes #51

The output of the Kibana API changed. I thought, I'd search for the information about the Elasticsearch connection. The change should work with Kibana 7.x and Kibana 8.x.

Quering the API: `curl -s -u elastic:***http://localhost:5601/api/status | jq`

Relevant part of the output Kibana 7.x:

```
    "name": "es01.example.com",
    "status": {
        "overall": {
            "icon": "success",
            "nickname": "Looking good",
            "since": "2023-02-10T12:33:51.454Z",
            "state": "green",
            "title": "Green",
            "uiColor": "secondary"
        },
```

Relevant part of the output of Kibana 8.x:

```
    "core": {
      "elasticsearch": {
        "level": "available",
        "summary": "Elasticsearch is available",
        "meta": {
          "warningNodes": [],
          "incompatibleNodes": []
        }
```