### PR TITLE
Add fileset for system module

### DIFF
--- a/docs/role-beats.md
+++ b/docs/role-beats.md
@@ -63,6 +63,7 @@ filebeat_journald_inputs:
 * *filebeat_docker_ids*: IDs of containers to collect. (default: `*`)
 
 * *filebeat_loadbalance*: Enable loadbalancing for Filebeats Logstash output (default: `true`)
+* *filebeat_modules*: **EXPERIMENTAL**: Give a list of modules to enable. (default: none)
 
 * *beats_auditbeat*: Install and manage filebeat (Default: `false`)
 * *beats_auditbeat_version*: Install specific version (Default: none. Possible values: e.g. `-7.10.1` for RedHat compatible systems or `=1:7.10.1-1` for Debian compatible systems or `latest`)

--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -37,28 +37,40 @@
     - filebeat_configuration
     - beats_configuration
 
-- name: Enable modules
-  command: "filebeat modules enable {{ item }}"
-  args:
-    creates: "/etc/filebeat/modules.d/{{ item }}.yml"
-  with_items: "{{ filebeat_modules }}"
+- name: Configure modules
   when: filebeat_modules is defined
+  with_items: "{{ filebeat_modules }}"
   tags:
     - configuration
     - filebeat_configuration
     - beats_configuration
+  block:
 
-- name: Enable Ingest Pipelines
-  command: >
-    /usr/bin/filebeat setup --pipelines --modules {{ item }} &&
-    /usr/bin/filebeat version > /etc/filebeat/{{ item }}_pipeline_created
-  args:
-    creates: "/etc/filebeat/{{ item }}_pipeline_created"
-  notify:
-    - Restart Filebeat
-  changed_when: false
-  with_items: "{{ filebeat_modules }}"
-  when: filebeat_modules is defined
+    - name: Enable modules
+      command: "filebeat modules enable {{ item }}"
+      args:
+        creates: "/etc/filebeat/modules.d/{{ item }}.yml"
+
+    - name: Enable Ingest Pipelines
+      command: >
+        /usr/bin/filebeat setup --pipelines --modules {{ item }} &&
+        /usr/bin/filebeat version > /etc/filebeat/{{ item }}_pipeline_created
+      args:
+        creates: "/etc/filebeat/{{ item }}_pipeline_created"
+      notify:
+        - Restart Filebeat
+      changed_when: false
+
+    - name: Enable System module
+      template:
+        src: filebeat-system.yml.j2
+        dest: /etc/filebeat/modules.d/system.yml
+        owner: root
+        group: root
+        mode: 0644
+      when:
+        - item == 'system'
+        - elastic_release | int > 7
 
 - name: Start Filebeat
   service:

--- a/roles/beats/templates/filebeat-system.yml.j2
+++ b/roles/beats/templates/filebeat-system.yml.j2
@@ -1,0 +1,4 @@
+- module: system
+  syslog:
+    enabled: true
+    var.paths: ["{% if ansible_os_family == 'Debian' %}/var/log/syslog{% else %}/var/log/messages{% endif %}"]


### PR DESCRIPTION
fixes #54

Beginning with release version 8 you need to give a fileset for "system" module of filebeat. Version 7 just used defaults.

Since we are thinking about replacing modules by elastic agents and filebeat only without modules in special cases, I add a quick fix and flag it as experimental. Let's see how it works.