### PR TITLE
Failsafe for standalone usage

### DIFF
--- a/molecule/logstash_pipelines/converge.yml
+++ b/molecule/logstash_pipelines/converge.yml
@@ -30,6 +30,7 @@
     logstash_pipeline_identifier_field_name: "[mytest][pipelines]"
     logstash_pipeline_identifier_defaults: true
     elastic_release: "{{ lookup('env', 'ELASTIC_RELEASE') | int}}"
+    elastic_stack_full_stack: false
   tasks:
     - name: "Include Elastics repos role"
       include_role:

--- a/roles/beats/tasks/main.yml
+++ b/roles/beats/tasks/main.yml
@@ -18,6 +18,7 @@
       when:
         - beats_security | bool
         - elasticsearch_ca is undefined
+        - groups['elasticsearch'] is defined
       tags:
         - certificates
         - renew_ca

--- a/roles/elasticsearch/handlers/main.yml
+++ b/roles/elasticsearch/handlers/main.yml
@@ -13,3 +13,4 @@
     - elastic_stack_full_stack: true
     - "not 'renew_ca' in ansible_run_tags"
     - "not elastic_ca_will_expire_soon | bool"
+    - groups['kibana'] is defined

--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -56,7 +56,7 @@
   delegate_to: "{{ item }}"
   when:
     - "'renew_ca' in ansible_run_tags or elastic_ca_will_expire_soon | bool"
-    - - groups['logstash'] is defined
+    - groups['logstash'] is defined
 
 - name: Backup ca directory on elasticsearch ca host then remove
   block:

--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -54,7 +54,9 @@
     state: stopped
   with_items: "{{ groups['logstash'] }}"
   delegate_to: "{{ item }}"
-  when: "'renew_ca' in ansible_run_tags or elastic_ca_will_expire_soon | bool"
+  when:
+    - "'renew_ca' in ansible_run_tags or elastic_ca_will_expire_soon | bool"
+    - - groups['logstash'] is defined
 
 - name: Backup ca directory on elasticsearch ca host then remove
   block:

--- a/roles/kibana/tasks/kibana-security.yml
+++ b/roles/kibana/tasks/kibana-security.yml
@@ -11,7 +11,9 @@
 - name: Set elasticsearch_ca variable if not already done by user
   set_fact:
     elasticsearch_ca: "{{ groups['elasticsearch'][0] }}"
-  when: elasticsearch_ca is undefined
+  when:
+    - elasticsearch_ca is undefined
+    - groups['elasticsearch'] is defined
   tags:
     - certificates
     - renew_ca

--- a/roles/logstash/tasks/logstash-security.yml
+++ b/roles/logstash/tasks/logstash-security.yml
@@ -11,7 +11,9 @@
 - name: Set elasticsearch_ca variable if not already done by user
   set_fact:
     elasticsearch_ca: "{{ groups['elasticsearch'][0] }}"
-  when: elasticsearch_ca is undefined
+  when:
+    - elasticsearch_ca is undefined
+    - groups['elasticsearch'] is defined
   tags:
     - certificates
     - configuration

--- a/roles/logstash/templates/elasticsearch-output.conf.j2
+++ b/roles/logstash/templates/elasticsearch-output.conf.j2
@@ -20,7 +20,7 @@ filter {
 {% endif %}
 output {
   elasticsearch {
-    hosts => [ {% for host in logstash_elasticsearch %}"{{ hostvars[host].ansible_hostname }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
+    hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
     validate_after_inactivity => {{ logstash_validate_after_inactivity }}
 {% if elastic_stack_full_stack | bool and logstash_security is defined and logstash_security | bool and elastic_variant == "elastic" %}
     keystore => "{{ logstash_certs_dir }}/keystore.pfx"

--- a/roles/logstash/templates/logstash.yml.j2
+++ b/roles/logstash/templates/logstash.yml.j2
@@ -15,7 +15,7 @@ pipeline.ecs_compatibility: {{ logstash_global_ecs }}
 {% endif %}
 {% if logstash_legacy_monitoring | bool and elastic_stack_full_stack | bool and elastic_variant == "elastic" and elastic_release | int < 8 %}
 xpack.monitoring.enabled: true
-xpack.monitoring.elasticsearch.hosts: [ {% for host in logstash_elasticsearch %}"https://{{ hostvars[host].ansible_hostname }}:9200"{% if not loop.last %},{% endif %}{% endfor %} ]
+xpack.monitoring.elasticsearch.hosts: [ {% for host in logstash_elasticsearch %}"https://{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %} ]
 xpack.monitoring.elasticsearch.username: elastic
 xpack.monitoring.elasticsearch.password: {{ elastic_password_logstash.stdout }}
 xpack.monitoring.elasticsearch.ssl.certificate_authority: "{{ logstash_certs_dir }}/ca.crt"


### PR DESCRIPTION
fixes #112

The roles of this community can either be used together relying on tasks and facts of each other or standalone. We need to make sure that no task that runs in standalone mode tries to access information from other roles.