### PR TITLE
Fix example playbook

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -7,6 +7,7 @@ warn_list:
   - key-order[task]  # Ensure specific order of keys in mappings.
   - name[casing]
   - 'risky-shell-pipe'
+  - no-handler # backup of old certificates
 skip_list:
   - '106'
   - 'command-instead-of-module'


### PR DESCRIPTION
The example playbook we provided would have installed Elastic Stack on all hosts. When writing it a change about choosing hosts to install slipped my mind.

fixes #130