### PR TITLE
add logpath config, change order for path creation

### DIFF
--- a/docs/role-elasticsearch.md
+++ b/docs/role-elasticsearch.md
@@ -23,6 +23,8 @@ Role Variables
 * *elasticsearch_cert_will_expire_soon*: Set it to true to renew elasticsearch certificate (default: `false`), Or run the playbook with `--tags renew_elasticsearch_cert` to do that.
 * *elasticsearch_datapath*: Path where Elasticsearch will store it's data. (default: `/var/lib/elasticsearch` - the packages default)
 * *elasticsearch_create_datapath*: Create the path for data to store if it doesn't exist. (default: `false` - only useful if you change `elasticsearch_datapath`)
+* *elasticsearch_logpath*: Path where Elasticsearch will store it's logs. (default: `/var/log/elasticsearch` - the packages default)
+* *elasticsearch_create_logpath*: Create the path for log to store if it doesn't exist. (default: `false` - only useful if you change `elasticsearch_datapath`)
 * *elasticsearch_fs_repo*: List of paths that should be registered as repository for snapshots (only filesystem supported so far). (default: none) Remember, that every node needs access to the same share under the same path.
 * *elasticsearch_bootstrap_pw*: Bootstrap password for Elasticsearch (Default: `PleaseChangeMe`)
 * *elasticsearch_disable_systemcallfilterchecks*: Disable system call filter checks. This has a security impact but is necessary on some systems. Please refer to the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/_system_call_filter_check.html) for details. (default: `false`)

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -11,6 +11,8 @@ elasticsearch_http_security: true
 elasticsearch_http_protocol: http
 elasticsearch_datapath: /var/lib/elasticsearch
 elasticsearch_create_datapath: false
+elasticsearch_logpath: /var/log/elasticsearch
+elasticsearch_create_logpath: false
 elasticsearch_disable_systemcallfilterchecks: false
 elasticsearch_heap: "{{ [[(ansible_memtotal_mb // 1024) // 2, 30] | min, 1] | max }}"
 elasticsearch_pamlimits: true

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -71,6 +71,18 @@
     - Restart Elasticsearch
   when: elasticsearch_manage_yaml | bool
 
+- name: Create Elasticsearch directory
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: elasticsearch
+    group: elasticsearch
+    mode: "2750"
+  when: item.create | bool
+  loop:
+    - {create: "{{elasticsearch_create_logpath}}", path: "{{ elasticsearch_logpath }}" } 
+    - {create: "{{elasticsearch_create_datapath}}", path: "{{ elasticsearch_datapath }}" } 
+
 - name: Import Tasks elasticsearch-security.yml
   import_tasks: elasticsearch-security.yml
   when:
@@ -80,15 +92,6 @@
     - certificates
     - renew_ca
     - renew_es_cert
-
-- name: Create Elasticsearch data directory
-  file:
-    path: "{{ elasticsearch_datapath }}"
-    state: directory
-    owner: elasticsearch
-    group: elasticsearch
-    mode: "2750"
-  when: elasticsearch_create_datapath | bool
 
 - name: Activate JNA workaround (see README.md)
   lineinfile:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -80,8 +80,8 @@
     mode: "2750"
   when: item.create | bool
   loop:
-    - {create: "{{elasticsearch_create_logpath}}", path: "{{ elasticsearch_logpath }}" } 
-    - {create: "{{elasticsearch_create_datapath}}", path: "{{ elasticsearch_datapath }}" } 
+    - {create: "{{elasticsearch_create_logpath}}", path: "{{ elasticsearch_logpath }}" }
+    - {create: "{{elasticsearch_create_datapath}}", path: "{{ elasticsearch_datapath }}" }
 
 - name: Import Tasks elasticsearch-security.yml
   import_tasks: elasticsearch-security.yml

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -1,6 +1,6 @@
 node.name: "{{ ansible_hostname }}"
 path.data: {{ elasticsearch_datapath }}
-path.logs: /var/log/elasticsearch
+path.logs: {{ elasticsearch_logpath }}
 network.host: ["_local_","_site_"]
 {% if elastic_release | int < 8 or groups['elasticsearch'] | length > 1 %}
 discovery.seed_hosts: [ {% for host in groups['elasticsearch']  %}


### PR DESCRIPTION
We need to configure the path for elasicsearch logs. 

We change the folder creation order. First folder creation than start services within elasticsearch-security.yml.
The data directory must exist while first start the elasticsearch service, otherwise the start will fail.