### PR TITLE
Fixed workflow for plugins

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -50,7 +50,6 @@ jobs:
           - debian10
         scenario:
           - elasticstack_default
-          - plugins
         release:
           - 7
           - 8


### PR DESCRIPTION
The full-stack workflow for plugins didn't work, since it has no complete molecule scenario and is only executed on the runner. I removed the plugin's scenario from it. https://github.com/NETWAYS/ansible-collection-elasticstack/actions/runs/4862046856