### PR TITLE
Reduce pipelines

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -1,12 +1,17 @@
 ---
-name: Test ElasticStack
+name: Test ElasticStack before release
 on:
-  push:
-    tags:
-      - '*'
-    branches:
-      - main
-  merge_group:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
 
 jobs:
 
@@ -46,6 +51,7 @@ jobs:
         distro:
           - ubuntu2004
           - debian10
+          - rockylinux9
         scenario:
           - elasticstack_default
         release:

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -44,9 +44,7 @@ jobs:
       max-parallel: 1
       matrix:
         distro:
-          - rockylinux8
           - ubuntu2004
-          - ubuntu2204
           - debian10
         scenario:
           - elasticstack_default

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -3,6 +3,7 @@ name: Test Collection Roles
 on:
   pull_request:
     branches:
+      - "main"
       - 'feature/**'
       - 'fix/**'
       - '!doc/**'

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -3,7 +3,6 @@ name: Test Collection Roles
 on:
   pull_request:
     branches:
-      - "main"
       - 'feature/**'
       - 'fix/**'
       - '!doc/**'

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -3,7 +3,6 @@ name: Test Collection Roles
 on:
   pull_request:
     branches:
-      - 'main'
       - 'feature/**'
       - 'fix/**'
       - '!doc/**'

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -7,8 +7,8 @@ on:
       - 'fix/**'
       - '!doc/**'
 
-  merge_group:
-    types: [checks_requested]
+#  merge_group:
+#    types: [checks_requested]
 
 jobs:
   lint_full:


### PR DESCRIPTION
* Fix #170  remove repetitive pipelines
* Make full stack pipelines run manually before release. 

We can run this very big pipeline before release manually on a specific branch e.g. main. When we get error we can fix it in another branch and then merge in main. The benefit from this:
* We should not wait long time before every PR merge. We wait only before the release.
* It is easier to debug. We should not wait on `test_role_pr` workflow then on `test_full_stack` to see if our fix work or not, when we have problem in the `test_full_stack`. The waiting time is about 3.5 hours. Now we can comment out all container, where our code worked, then test fixes on not working containers and run the CI/CD manually until we get every thing fixed.