### PR TITLE
Replace `molecule-docker` with `molecule-plugins[docker]`

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 ansible
 ansible-lint
 molecule
-molecule-docker
+molecule-plugins[docker]
 pytest


### PR DESCRIPTION
Moving to newer versions of molecule, this seems to be neccessary. Refer to e.g. https://dailystuff.nl/blog/2023/switch-to-molecule-plugins