### PR TITLE
Fix/lint workflow 192

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -17,30 +17,8 @@ on:
 
 jobs:
 
-  lint_full:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint .
-          ansible-lint roles/
-
   molecule_full_stack_every_os:
     runs-on: ubuntu-latest
-    needs: lint_full
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -22,8 +22,8 @@ jobs:
       rolename: ''
 
   molecule_full_stack_every_os:
-    runs-on: ubuntu-latest
     needs: lint_full
+    runs-on: ubuntu-latest
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -16,27 +16,10 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
-
   lint_full:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint .
-          ansible-lint roles/
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: ''
 
   molecule_full_stack_every_os:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -17,8 +17,30 @@ on:
 
 jobs:
 
+  lint_full:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint .
+          ansible-lint roles/
+
   molecule_full_stack_every_os:
     runs-on: ubuntu-latest
+    needs: lint_full
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -1,0 +1,75 @@
+---
+name: Test Linting
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - '!doc/**'
+    paths:
+      - 'roles/**'
+      - '.github/workflows/test_linting.yml'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
+  pull_request:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - '!doc/**'
+    paths:
+      - 'roles/**'
+      - '.github/workflows/test_linting.yml'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code (yamllint).
+        run: |
+          yamllint .
+
+      - name: Lint Role beats (ansible-lint).
+        run: |
+          ansible-lint roles/beats
+
+      - name: Lint Role elasticsearch (ansible-lint).
+        run: |
+          ansible-lint roles/elasticsearch
+
+      - name: Lint Role kibana (ansible-lint).
+        run: |
+          ansible-lint roles/kibana
+
+      - name: Lint Role logstash (ansible-lint).
+        run: |
+          ansible-lint roles/logstash
+
+      - name: Lint Role repos (ansible-lint).
+        run: |
+          ansible-lint roles/repos

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Lint Role (yamllint).
         run: |
-          ansible-lint roles/${{ inputs.rolename:-'' }}
+          ansible-lint roles/${{ inputs.rolename }}
         if: ${{ inputs.rolename != '' }}
 
       - name: Lint Role (ansible-lint).
         run: |
-          ansible-lint roles/${{ inputs.rolename:-'' }}
+          ansible-lint roles/${{ inputs.rolename }}

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -12,13 +12,17 @@ on:
           - info
           - warning
           - debug
+  workflow_call:
+    inputs:
+      rolename:
+        required: true
+        type: string
   push:
     branches:
       - 'feature/**'
       - 'fix/**'
       - '!doc/**'
     paths:
-      - 'roles/**'
       - '.github/workflows/test_linting.yml'
       - '.config/ansible-lint.yml'
       - '.yamllint'
@@ -28,7 +32,6 @@ on:
       - 'fix/**'
       - '!doc/**'
     paths:
-      - 'roles/**'
       - '.github/workflows/test_linting.yml'
       - '.config/ansible-lint.yml'
       - '.yamllint'
@@ -53,23 +56,13 @@ jobs:
       - name: Lint code (yamllint).
         run: |
           yamllint .
+        if: ${{ inputs.rolename == '' }}
 
-      - name: Lint Role beats (ansible-lint).
+      - name: Lint Role (yamllint).
         run: |
-          ansible-lint roles/beats
+          ansible-lint roles/${{ inputs.rolename:-'' }}
+        if: ${{ inputs.rolename != '' }}
 
-      - name: Lint Role elasticsearch (ansible-lint).
+      - name: Lint Role (ansible-lint).
         run: |
-          ansible-lint roles/elasticsearch
-
-      - name: Lint Role kibana (ansible-lint).
-        run: |
-          ansible-lint roles/kibana
-
-      - name: Lint Role logstash (ansible-lint).
-        run: |
-          ansible-lint roles/logstash
-
-      - name: Lint Role repos (ansible-lint).
-        run: |
-          ansible-lint roles/repos
+          ansible-lint roles/${{ inputs.rolename:-'' }}

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -21,8 +21,6 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,30 +30,12 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
   lint_beats:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/beats/
-          ansible-lint roles/beats/
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: beats
 
   molecule_beats:
     needs: lint_beats

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -1,6 +1,11 @@
 ---
 name: Test Role beats
 on:
+  workflow_run:
+    workflows:
+      - Test Linting
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -21,8 +26,6 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,33 +35,9 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
-  lint_beats:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/beats/
-          ansible-lint roles/beats/
-
   molecule_beats:
-    needs: lint_beats
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -1,11 +1,6 @@
 ---
 name: Test Role beats
 on:
-  workflow_run:
-    workflows:
-      - Test Linting
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -26,6 +21,8 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -35,9 +32,33 @@ on:
       - 'roles/beats/**'
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
 
 jobs:
+  lint_beats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint roles/beats/
+          ansible-lint roles/beats/
+
   molecule_beats:
+    needs: lint_beats
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -1,10 +1,6 @@
 ---
 name: Test Role elasticsearch
 on:
-  workflow_run:
-    workflows: [Test Linting]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -25,6 +21,8 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -34,9 +32,33 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
 
 jobs:
+  lint_elasticsearch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint roles/elasticsearch/
+          ansible-lint roles/elasticsearch/
+
   molecule_elasticsearch:
+    needs: lint_elasticsearch
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -21,8 +21,6 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,30 +30,12 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
   lint_elasticsearch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/elasticsearch/
-          ansible-lint roles/elasticsearch/
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: elasticsearch
 
   molecule_elasticsearch:
     needs: lint_elasticsearch

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -1,6 +1,10 @@
 ---
 name: Test Role elasticsearch
 on:
+  workflow_run:
+    workflows: [Test Linting]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -21,8 +25,6 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,33 +34,9 @@ on:
       - 'roles/elasticsearch/**'
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
-  lint_elasticsearch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/elasticsearch/
-          ansible-lint roles/elasticsearch/
-
   molecule_elasticsearch:
-    needs: lint_elasticsearch
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -21,8 +21,6 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,30 +30,13 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
   lint_kibana:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: kibana
 
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/kibana/
-          ansible-lint roles/kibana/
 
   molecule_kibana:
     needs: lint_kibana

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -1,6 +1,11 @@
 ---
 name: Test Role Kibana
 on:
+  workflow_run:
+    workflows:
+      - Test Linting
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -21,8 +26,6 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,33 +35,9 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
-  lint_kibana:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/kibana/
-          ansible-lint roles/kibana/
-
   molecule_kibana:
-    needs: lint_kibana
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -1,11 +1,6 @@
 ---
 name: Test Role Kibana
 on:
-  workflow_run:
-    workflows:
-      - Test Linting
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -26,6 +21,8 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -35,9 +32,33 @@ on:
       - 'roles/kibana/**'
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
 
 jobs:
+  lint_kibana:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint roles/kibana/
+          ansible-lint roles/kibana/
+
   molecule_kibana:
+    needs: lint_kibana
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -21,8 +21,6 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,30 +30,12 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
   lint_logstash:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/logstash/
-          ansible-lint roles/logstash/
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: logstash
 
   molecule_logstash:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -1,11 +1,6 @@
 ---
 name: Test Role Logstash
 on:
-  workflow_run:
-    workflows:
-      - Test Linting
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -26,6 +21,8 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -35,10 +32,34 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
 
 jobs:
+  lint_logstash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint roles/logstash/
+          ansible-lint roles/logstash/
+
   molecule_logstash:
     runs-on: ubuntu-latest
+    needs: lint_logstash
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -1,6 +1,11 @@
 ---
 name: Test Role Logstash
 on:
+  workflow_run:
+    workflows:
+      - Test Linting
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -21,8 +26,6 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -32,34 +35,10 @@ on:
       - 'roles/logstash/**'
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
-  lint_logstash:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/logstash/
-          ansible-lint roles/logstash/
-
   molecule_logstash:
     runs-on: ubuntu-latest
-    needs: lint_logstash
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -38,8 +38,8 @@ jobs:
       rolename: logstash
 
   molecule_logstash:
-    runs-on: ubuntu-latest
     needs: lint_logstash
+    runs-on: ubuntu-latest
 
     env:
       COLLECTION_NAMESPACE: netways
@@ -80,8 +80,8 @@ jobs:
           ELASTIC_RELEASE: ${{ matrix.release }}
 
   molecule_logstash_extended:
-    runs-on: ubuntu-latest
     needs: molecule_logstash
+    runs-on: ubuntu-latest
 
     env:
       COLLECTION_NAMESPACE: netways

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -20,8 +20,6 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -31,30 +29,12 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
   lint_repos:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/repos/
-          ansible-lint roles/repos/
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: repos
 
   molecule_repos:
     needs: lint_repos

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -1,10 +1,5 @@
 name: Test Role repos
 on:
-  workflow_run:
-    workflows:
-      - Test Linting
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -25,6 +20,8 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -34,9 +31,33 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
+      - '.config/ansible-lint.yml'
+      - '.yamllint'
 
 jobs:
+  lint_repos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Lint code.
+        run: |
+          yamllint roles/repos/
+          ansible-lint roles/repos/
+
   molecule_repos:
+    needs: lint_repos
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -1,5 +1,10 @@
 name: Test Role repos
 on:
+  workflow_run:
+    workflows:
+      - Test Linting
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       logLevel:
@@ -20,8 +25,6 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'
@@ -31,33 +34,9 @@ on:
       - 'roles/repos/**'
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
 
 jobs:
-  lint_repos:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint roles/repos/
-          ansible-lint roles/repos/
-
   molecule_repos:
-    needs: lint_repos
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -13,25 +13,10 @@ on:
 
 jobs:
   lint_full:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
+    uses: ./.github/workflows/test_linting.yml
+    with:
+      rolename: ''
 
-      - name: Set up Python 3.
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-test.txt
-
-      - name: Lint code.
-        run: |
-          yamllint .
-          ansible-lint roles/
   molecule_full_stack:
     runs-on: ubuntu-latest
     needs: lint_full

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -18,8 +18,8 @@ jobs:
       rolename: ''
 
   molecule_full_stack:
-    runs-on: ubuntu-latest
     needs: lint_full
+    runs-on: ubuntu-latest
 
     env:
       COLLECTION_NAMESPACE: netways


### PR DESCRIPTION
Fix #192.

This PR introduces a reusable workflow. This general workflow handles the job necessary to run both `ansible-lint` and `yamllint` on **either** all roles or one specific role.  

All roles are linted when:
- linting rules are changed
- the linting workflow is changed

Specific roles are linted when:
- a role specific workflow is triggered (linting as first job)
- the `full_stack` workflow is triggered (linting as first job)

The workflow for the specific role now uses a call to the general linting workflow, while providing it with its own role name.

This approach does not completely remove linting from single workflows, but it makes those linting jobs much more readable and reduces redundant code, while also allowing for a bit more flexibility.