### PR TITLE
Change used module from 'command' to 'shell' to allow shell redirect

### DIFF
--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -87,7 +87,7 @@
         - elasticstack_release | int > 7
 
     - name: Enable Ingest Pipelines
-      command: >
+      shell: >
         /usr/bin/filebeat setup --pipelines &&
         /usr/bin/filebeat version > /etc/filebeat/{{ item }}_pipeline_created
       args:


### PR DESCRIPTION
Fix #198

This PR adjusts a task that used the `command` module with a command that wants to redirect output into a file.  
This, however, is not possible since no actual shell is used, thus making that redirect impossible. The Ingest Pipelines were never created.  
Changed the `command` module to the `shell` module. 