### PR TITLE
Check for license to be set

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -593,7 +593,7 @@
   no_log: true
   when:
     - elasticsearch_passwords_file.stat.exists | bool
-    - groups['elasticsearch'] | length > 1
+    - groups['elasticsearch'] | length > 1 or elasticstack_release > 7
   until: elasticsearch_cluster_status.stdout == "green"
   retries: 20
   delay: 10
@@ -629,5 +629,39 @@
     group: root
     mode: 0600
   when: inventory_hostname == elasticstack_ca
+
+- name: Check for passwords being set
+  stat:
+    path: "{{ elasticstack_initial_passwords }}"
+  delegate_to: "{{ elasticstack_ca }}"
+  register: elasticsearch_passwords_file
+
+- name: Fetch Elastic password # noqa: risky-shell-pipe
+  shell: >
+    if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
+    grep "PASSWORD elastic" {{ elasticstack_initial_passwords }} |
+    awk {' print $4 '}
+  register: elasticstack_password
+  changed_when: false
+  no_log: true
+  delegate_to: "{{ elasticstack_ca }}"
+  when: elasticsearch_passwords_file.stat.exists | bool
+
+- name: Check for cluster license with elastic password # noqa: risky-shell-pipe
+  shell: >
+    if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
+    curl -ks
+    {{ elasticsearch_http_protocol }}://elastic:{{ elasticstack_password.stdout }}@localhost:{{ elasticstack_elasticsearch_http_port }}/_license?pretty |
+    grep status |
+    cut -d\" -f4
+  register: elasticsearch_cluster_license
+  changed_when: false
+#  no_log: true
+#  when:
+#    - elasticsearch_passwords_file.stat.exists | bool
+#    - groups['elasticsearch'] | length > 1 or elasticstack_release > 7
+  until: elasticsearch_cluster_license.stdout == "active"
+  retries: 20
+  delay: 10
 
 # Maybe make sure that Elasticsearch is using the right protocol http(s) to connect, even in newly setup clusters

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -207,6 +207,21 @@
       retries: 5
       delay: 10
 
+    - name: Check for cluster license without security # noqa: risky-shell-pipe
+      shell: >
+        if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
+        curl -s
+        http://localhost:{{ elastic_elasticsearch_http_port }}/_license?pretty |
+        grep status |
+        cut -d\" -f4
+      register: es_cluster_license
+      changed_when: false
+      no_log: true
+      ignore_errors: "{{ ansible_check_mode }}"
+      until: es_cluster_license.stdout == "active"
+      retries: 5
+      delay: 10
+
     - name: Leave a file showing that the cluster is set up
       template:
         dest: "{{ elasticsearch_initialized_file }}"

--- a/roles/elasticsearch/templates/jvm.options.j2
+++ b/roles/elasticsearch/templates/jvm.options.j2
@@ -19,8 +19,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 {% if elasticsearch_heap is defined %}
--Xms{{ elasticsearch_heap }}
--Xmx{{ elasticsearch_heap }}
+-Xms{{ elasticsearch_heap }}g
+-Xmx{{ elasticsearch_heap }}g
 {% else %}
 -Xms2g
 -Xmx2g


### PR DESCRIPTION
I had problems with setting up a single node stack vers. 8.

Here's the included changes:

* Check for license (I had errors showing that no license was yet created when trying to restart)
* Run checks even in single node clusters
* Type on `jvm.options`