### PR TITLE
Remove redundant default and fix typo

### DIFF
--- a/roles/elasticsearch/templates/jvm.options.j2
+++ b/roles/elasticsearch/templates/jvm.options.j2
@@ -18,13 +18,8 @@
 
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
-{% if elasticsearch_heap is defined %}
--Xms{{ elasticsearch_heap }}
--Xmx{{ elasticsearch_heap }}
-{% else %}
--Xms2g
--Xmx2g
-{% endif %}
+-Xms{{ elasticsearch_heap }}g
+-Xmx{{ elasticsearch_heap }}g
 
 {% if elasticstack_release is version('8', '>=') %}
 ################################################################


### PR DESCRIPTION
I removed the `else` that could never be used and fixed a typo.

fixes #232