### PR TITLE
* Remove cache after all roles run

### DIFF
--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -51,9 +51,8 @@ jobs:
       max-parallel: 2
       matrix:
         distro:
-          - centos8
-          #- rockylinux8
-          #- ubuntu2204
+          - rockylinux8
+          - ubuntu2204
         scenario:
           - elasticstack_default
         release:

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -51,8 +51,9 @@ jobs:
       max-parallel: 2
       matrix:
         distro:
-          - rockylinux8
-          - ubuntu2204
+          - centos8
+          #- rockylinux8
+          #- ubuntu2204
         scenario:
           - elasticstack_default
         release:

--- a/molecule/elasticstack_default/converge.yml
+++ b/molecule/elasticstack_default/converge.yml
@@ -49,6 +49,11 @@
     - name: Install rsyslog
       ansible.builtin.package:
         name: rsyslog
+    - name: Remove cache # noqa: risky-shell-pipe
+      ansible.builtin.shell: >
+        if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
+        rm -rf /var/cache/*
+      changed_when: false
     - name: Configure rsyslog
       ansible.builtin.lineinfile:
         line: "*.* @@localhost:514"

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -182,7 +182,6 @@
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
     rm -rf /var/cache/*
-  failed_when: false
   changed_when: false
   when: ansible_virtualization_type == "container" or ansible_virtualization_type == "docker"
 


### PR DESCRIPTION
We should free up space after the roles run to have green cluster state in impotence step and enable Elasticsearch to allocate all indices.

Close #272 