### PR TITLE
Replace quotations for passwords with special characters

### DIFF
--- a/molecule/elasticstack_default/converge.yml
+++ b/molecule/elasticstack_default/converge.yml
@@ -12,6 +12,7 @@
   vars:
     elasticsearch_jna_workaround: true
     elasticsearch_disable_systemcallfilterchecks: true
+    elasticsearch_tls_key_passphrase: 'test$var@test' # to test escaping
     elasticstack_release: "{{ lookup('env', 'ELASTIC_RELEASE') | int}}"
     elasticsearch_heap: "1"
     elasticstack_full_stack: true

--- a/roles/elasticsearch/tasks/elasticsearch-keystore.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-keystore.yml
@@ -13,7 +13,7 @@
 - name: Set bootstrap password # noqa: risky-shell-pipe
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
-    echo "{{ elasticsearch_bootstrap_pw }}" |
+    echo '{{ elasticsearch_bootstrap_pw }}' |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -x 'bootstrap.password'
   when: "'bootstrap.password' not in elasticsearch_keystore.stdout_lines"
@@ -39,7 +39,7 @@
 - name: Set xpack.security.http.ssl.keystore.secure_password # noqa: risky-shell-pipe
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
-    echo "{{ elasticsearch_tls_key_passphrase }}" |
+    echo '{{ elasticsearch_tls_key_passphrase }}' |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -f -x 'xpack.security.http.ssl.keystore.secure_password'
   changed_when: false
@@ -79,7 +79,7 @@
 - name: Set xpack.security.http.ssl.truststore.secure_password # noqa: risky-shell-pipe
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
-    echo "{{ elasticsearch_tls_key_passphrase }}" |
+    echo '{{ elasticsearch_tls_key_passphrase }}' |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -f -x 'xpack.security.http.ssl.truststore.secure_password'
   changed_when: false
@@ -119,7 +119,7 @@
 - name: Set xpack.security.transport.ssl.keystore.secure_password # noqa: risky-shell-pipe
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
-    echo "{{ elasticsearch_tls_key_passphrase }}" |
+    echo '{{ elasticsearch_tls_key_passphrase }}' |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -f -x 'xpack.security.transport.ssl.keystore.secure_password'
   changed_when: false
@@ -159,7 +159,7 @@
 - name: Set xpack.security.transport.ssl.truststore.secure_password # noqa: risky-shell-pipe
   ansible.builtin.shell: >
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
-    echo "{{ elasticsearch_tls_key_passphrase }}" |
+    echo '{{ elasticsearch_tls_key_passphrase }}' |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -f -x 'xpack.security.transport.ssl.truststore.secure_password'
   changed_when: false


### PR DESCRIPTION
Using special characters like `$` in some passwords breaks the role. This PR introduces a test (by setting passwords with special characters) and introduces a fix to handle them correctly.

fixes #282