### PR TITLE
Always run required checks

### DIFF
--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -13,23 +13,7 @@ on:
           - warning
           - debug
   pull_request:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/**'
-      - '.github/workflows/test_roles_pr.yml'
-      - 'molecule/elasticstack_default/**'
   push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/**'
-      - '.github/workflows/test_roles_pr.yml'
-      - 'molecule/elasticstack_default/**'
   merge_group:
 
 jobs:


### PR DESCRIPTION
We have quite sophisticated rules when to run which Molecule checks. Unfortunately it's quite easy to have a PR or push where the full stack checks won't run. But since we require these checks, you can end up in a situation where you don't have check results but can't merge without those results.

So I simplified the rules when to run these checks.

fixes #300