### PR TITLE
Remove actions for pushs 

### DIFF
--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -17,15 +17,6 @@ on:
       rolename:
         required: true
         type: string
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - '.github/workflows/test_linting.yml'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -19,13 +19,7 @@ on:
         type: string
   pull_request:
     branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - '.github/workflows/test_linting.yml'
-      - '.config/ansible-lint.yml'
-      - '.yamllint'
+      - '*'
 
 jobs:
   lint:

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -12,17 +12,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'plugins/**'
-      - '.github/workflows/test_plugins.yml'
-      - 'molecule/plugins/**'
-      - '.config/pep8.yml'
-      - 'tests/**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -12,15 +12,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/beats/**'
-      - '.github/workflows/test_role_beats.yml'
-      - 'molecule/beats_**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -12,15 +12,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/elasticsearch/**'
-      - '.github/workflows/test_role_elasticsearch.yml'
-      - 'molecule/elasticsearch_**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -12,15 +12,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/kibana/**'
-      - '.github/workflows/test_role_kibana.yml'
-      - 'molecule/kibana_**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -12,15 +12,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/logstash/**'
-      - '.github/workflows/test_role_logstash.yml'
-      - 'molecule/logstash_**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -11,15 +11,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-      - '!doc/**'
-    paths:
-      - 'roles/repos/**'
-      - '.github/workflows/test_role_repos.yml'
-      - 'molecule/repos_**'
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -13,7 +13,6 @@ on:
           - warning
           - debug
   pull_request:
-  push:
   merge_group:
 
 jobs:


### PR DESCRIPTION
At the moment workflows are triggered for PRs and pushs.

The workflow to contribute says that a PR must be created beforehand for each contribution into main.
For this reason (and to avoid duplicate workflows), github workflows should only be triggered for PRs.

I have also checked this branch before creating the PR. No workflow were scheduled.

Fixes #302 