### PR TITLE
Fix apt key handling

### DIFF
--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for elastic-repos
+elasticstack_repo_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 elasticstack_release: 8
 elasticstack_full_stack: true
 elasticstack_variant: elastic

--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -6,10 +6,16 @@
       - gpg-agent
     state: present
 
-- name: Ensure Elastic Stack key is available (Debian)
+- name: Ensure Elastic Stack key is configured (Debian legacy)
   ansible.builtin.apt_key:
     url: "{{ elasticstack_repo_key }}"
-    state: present
+    state: "{{ ((ansible_distribution_major_version | int) < 12) | ternary('present', 'absent') }}"
+
+- name: Ensure Elastic Stack key is available (Debian)
+  ansible.builtin.get_url:
+    url: "{{ elasticstack_repo_key }}"
+    dest: /etc/apt/trusted.gpg.d/elasticsearch.asc
+    mode: "0644"
 
 - name: Ensure Elastic Stack apt repository is configured (Debian)
   ansible.builtin.apt_repository:

--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure Elastic Stack key is available (Debian)
   ansible.builtin.apt_key:
-    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    url: "{{ elasticstack_repo_key }}"
     state: present
 
 - name: Ensure Elastic Stack apt repository is configured (Debian)

--- a/roles/repos/tasks/redhat.yml
+++ b/roles/repos/tasks/redhat.yml
@@ -36,7 +36,7 @@
 
 - name: Ensure Elastic repository key is available (RedHat)
   ansible.builtin.rpm_key:
-    key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    key: "{{ elasticstack_repo_key }}"
     state: present
 
 - name: Ensure Elastic Stack yum repository is configured (RedHat)
@@ -46,7 +46,7 @@
     file: elastic-release
     baseurl: https://artifacts.elastic.co/packages/{{ elasticstack_release }}.x/yum
     gpgcheck: yes
-    gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    gpgkey: "{{ elasticstack_repo_key }}"
     enabled: "{{ elasticstack_enable_repos | bool }}"
   when: elasticstack_variant == "elastic"
 
@@ -57,6 +57,6 @@
     file: elastic-oss-release
     baseurl: https://artifacts.elastic.co/packages/oss-{{ elasticstack_release }}.x/yum
     gpgcheck: yes
-    gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    gpgkey: "{{ elasticstack_repo_key }}"
     enabled: "{{ elasticstack_enable_repos | bool }}"
   when: elasticstack_variant == "oss"


### PR DESCRIPTION
avoid warning on debian 12
```
W:https://artifacts.elastic.co/packages/8.x/apt/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details
```