### PR TITLE
Fix apt key handling2

### DIFF
--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for elastic-repos
+elasticstack_repo_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 elasticstack_release: 8
 elasticstack_full_stack: true
 elasticstack_variant: elastic

--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -6,19 +6,37 @@
       - gpg-agent
     state: present
 
-- name: Ensure Elastic Stack key is available (Debian)
+- name: Ensure Elastic Stack key is removed (Debian legacy format)
   ansible.builtin.apt_key:
     url: "{{ elasticstack_repo_key }}"
-    state: present
+    state: absent
+
+- name: Ensure Elastic Stack key is available (Debian)
+  ansible.builtin.get_url:
+    url: "{{ elasticstack_repo_key }}"
+    dest: /usr/share/keyrings/elasticsearch.asc
+    mode: "0644"
+
+- name: Ensure Elastic Stack apt repo is absent (Debian legacy format)
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/artifacts_elastic_co_packages_{{ item }}_x_apt.list
+    state: absent
+  with_items:
+    - "7"
+    - "oss-7"
+    - "8"
+    - "oss-8"
 
 - name: Ensure Elastic Stack apt repository is configured (Debian)
   ansible.builtin.apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/{{ elasticstack_release }}.x/apt stable main
+    repo: deb [signed-by=/usr/share/keyrings/elasticsearch.asc] https://artifacts.elastic.co/packages/{{ elasticstack_release }}.x/apt stable main
     state: present
+    filename: elasticstack
   when: elasticstack_variant == "elastic"
 
 - name: Ensure Elastic Stack OSS apt repository is configured (Debian)
   ansible.builtin.apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/oss-{{ elasticstack_release }}.x/apt stable main
+    repo: deb [signed-by=/usr/share/keyrings/elasticsearch.asc] https://artifacts.elastic.co/packages/oss-{{ elasticstack_release }}.x/apt stable main
     state: present
+    filename: elasticstack
   when: elasticstack_variant == "oss"

--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure Elastic Stack key is available (Debian)
   ansible.builtin.apt_key:
-    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    url: "{{ elasticstack_repo_key }}"
     state: present
 
 - name: Ensure Elastic Stack apt repository is configured (Debian)

--- a/roles/repos/tasks/redhat.yml
+++ b/roles/repos/tasks/redhat.yml
@@ -36,7 +36,7 @@
 
 - name: Ensure Elastic repository key is available (RedHat)
   ansible.builtin.rpm_key:
-    key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    key: "{{ elasticstack_repo_key }}"
     state: present
 
 - name: Ensure Elastic Stack yum repository is configured (RedHat)
@@ -46,7 +46,7 @@
     file: elastic-release
     baseurl: https://artifacts.elastic.co/packages/{{ elasticstack_release }}.x/yum
     gpgcheck: yes
-    gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    gpgkey: "{{ elasticstack_repo_key }}"
     enabled: "{{ elasticstack_enable_repos | bool }}"
   when: elasticstack_variant == "elastic"
 
@@ -57,6 +57,6 @@
     file: elastic-oss-release
     baseurl: https://artifacts.elastic.co/packages/oss-{{ elasticstack_release }}.x/yum
     gpgcheck: yes
-    gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    gpgkey: "{{ elasticstack_repo_key }}"
     enabled: "{{ elasticstack_enable_repos | bool }}"
   when: elasticstack_variant == "oss"


### PR DESCRIPTION
f/u to #306 
Refactored key and sources list for debian based distros. Use current state of the art to include 3party repos.

 * avoid apt warning
   `W:https://artifacts.elastic.co/packages/8.x/apt/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details`
 * prepare for deb822 format:
   * > Entries MUST be added in the /etc/apt/sources.list.d directory using a shortened repository name
   * > A sources.list entry SHOULD have the signed-by option set.

see: https://wiki.debian.org/DebianRepository/UseThirdParty

PS: this time I have run the checks in question (sorry for my carelessness in the other PR):
 * https://github.com/Rosa-Luxemburgstiftung-Berlin/ansible-collection-elasticstack/actions/runs/7677838360
 * https://github.com/Rosa-Luxemburgstiftung-Berlin/ansible-collection-elasticstack/actions/runs/7677869397