### PR TITLE
fixed filebeat config template to actually use tcp and udp port vars

### DIFF
--- a/roles/beats/templates/filebeat.yml.j2
+++ b/roles/beats/templates/filebeat.yml.j2
@@ -56,7 +56,7 @@ filebeat.inputs:
 - type: tcp
   enabled: true
   max_message_size: 10MiB
-  host: "0.0.0.0:514"
+  host: "0.0.0.0:{{ beats_filebeat_syslog_tcp_port }}"
 {% if beats_fields is defined %}
   fields:
 {% for field in beats_fields %}
@@ -69,7 +69,7 @@ filebeat.inputs:
 - type: udp
   enabled: true
   max_message_size: 10MiB
-  host: "0.0.0.0:514"
+  host: "0.0.0.0:{{ beats_filebeat_syslog_udp_port }}"
 {% if beats_fields is defined %}
   fields:
 {% for field in beats_fields %}


### PR DESCRIPTION
Filebeat.yml.j2 now uses the vars `beats_filebeat_syslog_tcp_port` and `beats_filebeat_syslog_tcp_port` for the udp and tcp inputs. 

Fixes #309 