### PR TITLE
Enforce repos only with full stack

### DIFF
--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -10,13 +10,22 @@
       string if elasticstack_version is defined else '') |
       replace(' ', '')
       }}
-- name: Install Auditbeat - rpm
+
+- name: Install Auditbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Auditbeat - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ beats_auditbeat_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Auditbeat - deb
   ansible.builtin.package:
@@ -24,7 +33,7 @@
   when:
     - ansible_os_family == "Debian"
 
-- name: Install Auditbeat latest version - rpm
+- name: Install Auditbeat latest version - rpm - full stack
   ansible.builtin.package:
     name: auditbeat
     state: latest
@@ -36,6 +45,19 @@
     - elasticstack_version is defined
     - elasticstack_version == "latest"
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Auditbeat latest version - rpm - standalone
+  ansible.builtin.package:
+    name: auditbeat
+    state: latest
+  notify:
+    - Restart Auditbeat
+  when:
+    - elasticstack_version is defined
+    - elasticstack_version == "latest"
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Auditbeat latest version - deb
   ansible.builtin.package:

--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -10,13 +10,21 @@
       string if elasticstack_version is defined else '') |
       replace(' ', '') }}
 
-- name: Install Filebeat - rpm
+- name: Install Filebeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Filebeat - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ beats_filebeat_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Filebeat - deb
   ansible.builtin.package:
@@ -24,7 +32,7 @@
   when:
     - ansible_os_family == "Debian"
 
-- name: Install Filebeat latest version - rpm
+- name: Install Filebeat latest version - rpm - full stack
   ansible.builtin.package:
     name: filebeat
     state: latest
@@ -36,6 +44,19 @@
     - elasticstack_version is defined
     - elasticstack_version == "latest"
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Filebeat latest version - rpm - standalone
+  ansible.builtin.package:
+    name: filebeat
+    state: latest
+  notify:
+    - Restart Filebeat
+  when:
+    - elasticstack_version is defined
+    - elasticstack_version == "latest"
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Filebeat latest version - deb
   ansible.builtin.package:

--- a/roles/beats/tasks/metricbeat.yml
+++ b/roles/beats/tasks/metricbeat.yml
@@ -11,13 +11,21 @@
       replace(' ', '')
       }}
 
-- name: Install Metricbeat - rpm
+- name: Install Metricbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Metricbeat - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ beats_metricbeat_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Metricbeat - deb
   ansible.builtin.package:
@@ -25,7 +33,7 @@
   when:
     - ansible_os_family == "Debian"
 
-- name: Install Metricbeat latest version - rpm
+- name: Install Metricbeat latest version - rpm - full stack
   ansible.builtin.package:
     name: metricbeat
     state: latest
@@ -37,6 +45,20 @@
     - elasticstack_version is defined
     - elasticstack_version == "latest"
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Metricbeat latest version - rpm - standalone
+  ansible.builtin.package:
+    name: metricbeat
+    state: latest
+  notify:
+    - Restart Metricbeat
+  when:
+    - elasticstack_version is defined
+    - elasticstack_version == "latest"
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
+
 
 - name: Install Metricbeat latest version - deb
   ansible.builtin.package:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -121,13 +121,21 @@
       replace(' ', '')
       }}
 
-- name: Install Elasticsearch - rpm
+- name: Install Elasticsearch - rpm - full stack
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Elasticsearch - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ elasticsearch_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Elasticsearch - deb
   ansible.builtin.package:

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -45,13 +45,21 @@
       string if elasticstack_version is defined else '') |
       replace(' ', '') }}
 
-- name: Install Kibana - rpm
+- name: Install Kibana - rpm - full stack
   ansible.builtin.package:
     name: "{{ kibana_package }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Kibana - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ kibana_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Kibana - deb
   ansible.builtin.package:

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -70,13 +70,21 @@
       replace(' ', '')
       }}
 
-- name: Install Logstash - rpm
+- name: Install Logstash - rpm - full stack
   ansible.builtin.package:
     name: "{{ logstash_package }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   when:
     - ansible_os_family == "RedHat"
+    - elasticstack_full_stack | bool
+
+- name: Install Logstash - rpm - standalone
+  ansible.builtin.package:
+    name: "{{ logstash_package }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - not elasticstack_full_stack | bool
 
 - name: Install Logstash - deb
   ansible.builtin.package:


### PR DESCRIPTION
RPM installation automatically enabled the Elastic Stack repositories this collection will add to a host. But if you have another tool to manage your repositories, they might have other ids and names.

So I added separate installation tasks. If `elasticstack_full_stack` is set to `true`, everything stays as it was. The task will forcefully enable the repository and then install the package.

But if `elasticstack_full_stack` is set to `false` it will just ignore the repository and expect the package to be available.

While working on this I found a different approach to choosing the correct version in the `beats` role. I couldn't afford to fix it all in a single PR so I opened #313 for this.

fixes #312