### PR TITLE
Use elasticsearch_network_host for connection tests if defined

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -391,7 +391,7 @@
 
 - name: Check for API with bootstrap password
   ansible.builtin.uri:
-    url: "{{ elasticsearch_http_protocol }}://localhost:{{ elasticstack_elasticsearch_http_port }}"
+    url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_network_host|default('localhost') }}:{{ elasticstack_elasticsearch_http_port }}"
     user: elastic
     password: "{{ elasticsearch_bootstrap_pw }}"
     validate_certs: false
@@ -410,7 +410,7 @@
 
 - name: Check for cluster status with bootstrap password
   ansible.builtin.uri:
-    url: "{{ elasticsearch_http_protocol }}://localhost:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
+    url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_network_host|default('localhost') }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
     user: elastic
     password: "{{ elasticsearch_bootstrap_pw }}"
     validate_certs: false
@@ -437,7 +437,7 @@
 
 - name: Check for API availability with elastic password
   ansible.builtin.uri:
-    url: "{{ elasticsearch_http_protocol }}://localhost:{{ elasticstack_elasticsearch_http_port }}"
+    url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_network_host|default('localhost') }}:{{ elasticstack_elasticsearch_http_port }}"
     user: elastic
     password: "{{ elasticstack_password.stdout }}"
     validate_certs: false
@@ -466,7 +466,7 @@
         curl
         -k
         -X PUT
-        "{{ elasticsearch_http_protocol }}://elastic:{{ elasticstack_password.stdout }}@localhost:9200/_cluster/settings"
+        "{{ elasticsearch_http_protocol }}://elastic:{{ elasticstack_password.stdout }}@{{ elasticsearch_network_host|default('localhost') }}:9200/_cluster/settings"
         -H 'Content-Type: application/json' -d
         '
         {
@@ -488,7 +488,7 @@
 
 - name: Check for cluster status with elastic password
   ansible.builtin.uri:
-    url: "{{ elasticsearch_http_protocol }}://localhost:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
+    url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_network_host|default('localhost') }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
     user: elastic
     password: "{{ elasticstack_password.stdout }}"
     validate_certs: false


### PR DESCRIPTION
When `elasticsearch_network_host` is set to something not including localhost, all connection tests fails. 

This uses `elasticsearch_network_host` for connections if it is defined, and falls back to localhost if not. 

(There might be more places this change should be made, but the role works for me with this fix)