### PR TITLE
Add beats timeout to Logstash

### DIFF
--- a/docs/role-logstash.md
+++ b/docs/role-logstash.md
@@ -60,6 +60,7 @@ Aside from `logstash.yml` we can manage Logstashs pipelines.
 * *logstash_ident_field_name*: Name of the identifying the instance (default: `"[netways][instance]"`)
 * *logstash_beats_input*: Enable default pipeline with `beats` input (default: `true`)
 * *logstash_beats_input_congestion*: Optional congestion threshold for the beats input pipeline
+* *logstash_beats_timeout*: Optional timeout for client connections. (Example: `60s`)
 * *logstash_beats_tls*: Activate TLS for the beats input pipeline (default: none but `true` with full stack setup if not set)
 * *logstash_tls_key_passphrase*: Passphrase for Logstash certificates (default: `LogstashChangeMe`)
 * *elasticstack_ca_pass*: Password for Elasticsearch CA (default: `PleaseChangeMe`)

--- a/roles/logstash/templates/beats-input.conf.j2
+++ b/roles/logstash/templates/beats-input.conf.j2
@@ -9,6 +9,9 @@ input {
     ssl_certificate_authorities => ["{{ logstash_certs_dir }}/ca.crt"]
     ssl_peer_metadata => false
 {% endif %}
+{% if logstash_beats_timeout is defined %}
+    client_inactivity_timeout => "{{ logstash_beats_timeout }}"
+{% endif %}
 
   }
 }


### PR DESCRIPTION
fixes #321

This will add an optional client timeout to the `beats` input the collection provides. 

See https://www.elastic.co/guide/en/logstash/7.17/plugins-inputs-beats.html#plugins-inputs-beats-client_inactivity_timeout for details.