### PR TITLE
Re-enable RPM tests

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          # - rockylinux8
-          # - rockylinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu2004
           - ubuntu2204
           - debian10

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -43,8 +43,8 @@ jobs:
           - centos7
           - debian10
           - debian11
-          # - rockylinux8
-          # - rockylinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu2004
           - ubuntu2204]
         scenario:

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -33,7 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          #- rockylinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu2204
         scenario:
           - elasticstack_default


### PR DESCRIPTION
We had to disable tests on rpm-based distributions due to a bug in Elasticsearch. This PR will bring them back.

fixes #327