### PR TITLE
Fix Python module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every role is documented with all variables, please refer to the documentation f
 
 ## Global variables
 
-* `elasticstack_force_pip`: Will force installation of required Python modules via `pip`. This is useful if your package manager doesn't provide current versions of modules. (Default: `false`)
+* `elasticstack_force_pip`: Will force installation of required Python modules via `pip`. This is useful if your package manager doesn't provide current versions of modules. (Default: `false`) See [PEP668](https://peps.python.org/pep-0668/) for more details.
 * `elasticstack_manage_pip`: Will install `pip` on your system. (Default: `false`)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Every role is documented with all variables, please refer to the documentation f
 * [elasticsearch_role](docs/module-elasticsearch_role.md)
 * [elasticsearch_user](docs/module-elasticsearch_user.md)
 
+## Global variables
+
+* `elasticstack_force_pip`: Will force installation of required Python modules via `pip`. This is useful if your package manager doesn't provide current versions of modules. (Default: `false`)
+* `elasticstack_manage_pip`: Will install `pip` on your system. (Default: `false`)
+
 ## Installation
 
 You can easily install the collection with the `ansible-galaxy` command.

--- a/roles/elasticstack/defaults/main.yml
+++ b/roles/elasticstack/defaults/main.yml
@@ -22,6 +22,8 @@ elasticstack_repo_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 elasticstack_rpm_workaround: false
 elasticstack_security: true
 elasticstack_variant: elastic
+elasticstack_force_pip: false
+elasticstack_manage_pip: false
 
   # for debugging only
 elasticstack_no_log: true

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -28,8 +28,8 @@
   ansible.builtin.package:
     name:
       - python3-pip
-    when:
-      - elasticstack_manage_pip | bool
+  when:
+    - elasticstack_manage_pip | bool
 
 # The following block will try to install modules via pip
 # If that fails it will try to install them via package manager

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -23,7 +23,6 @@
 - name: Install packages for module dependencies
   ansible.builtin.package:
     name:
-      - python3
       - python3-pip
 
 - name: Install Elasticsearch Python Module

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -20,12 +20,51 @@
     - renew_es_cert
     - renew_logstash_cert
 
+# We don't know how the user made `pip` available and we don't want
+# to mess with the installation.
+# But we need a way to install our dependencies
+
 - name: Install packages for module dependencies
   ansible.builtin.package:
     name:
       - python3-pip
+    when:
+      - elasticstack_manage_pip | bool
 
-- name: Install Elasticsearch Python Module
+# The following block will try to install modules via pip
+# If that fails it will try to install them via package manager
+# Packets are sometimes too old as a dependency, so pip is
+# preferred
+# If that's the case the next task will allow breaking
+# systems Python and just install it via pip no matter what 
+
+- name: Install Python Modules as dependencies
+  when:
+    - not elasticstack_force_pip | bool
+  block:
+    - name: Install Python Modules via pip
+      ansible.builtin.pip:
+        name:
+          - elasticsearch
+          - cryptography
+      ignore_errors: true
+      register: elasticstack_pip_installation
+    
+    - name: Install Python Module via package manager
+      ansible.builtin.package:
+        name:
+          - python3-elasticsearch
+          - cryptography
+      when:
+        - elasticstack_pip_installation
+
+- name: Install Python Modules via pip  - forced
   ansible.builtin.pip:
     name:
       - elasticsearch
+      - cryptography
+    break_system_packages: true
+  ignore_errors: true
+  when:
+    - elasticstack_force_pip | bool
+  register: elasticstack_pip_installation_forced

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -36,7 +36,7 @@
 # Packets are sometimes too old as a dependency, so pip is
 # preferred
 # If that's the case the next task will allow breaking
-# systems Python and just install it via pip no matter what 
+# systems Python and just install it via pip no matter what
 
 - name: Install Python Modules as dependencies
   when:
@@ -49,7 +49,7 @@
           - cryptography
       ignore_errors: true
       register: elasticstack_pip_installation
-    
+
     - name: Install Python Module via package manager
       ansible.builtin.package:
         name:

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -54,7 +54,7 @@
       ansible.builtin.package:
         name:
           - python3-elasticsearch
-          - cryptography
+          - python3-cryptography
       when:
         - elasticstack_pip_installation
 


### PR DESCRIPTION
There are several ways of installing Python modules on a system. We can't make safe assumptions about the system where the collection is used.

Possible problems:
* Modules available via package manager can be too old
* Python could be entirely managed via package manager and pip wouldn't break that
* Pip could be installed in different ways

This change will do the following:

* Install `pip` via package manager if a new variable is set
* Try to install modules via pip
* If that fails because Python is managed via package manager, try installing them via package manager
* One of the above methods should be successful but you still might end up with modules which are too old to work
* If that's the case you can force the installation via pip and break the managed Python installation

fixes #334 