### PR TITLE
Reload daemons for Logstash restart

### DIFF
--- a/roles/logstash/handlers/main.yml
+++ b/roles/logstash/handlers/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.service:
     name: logstash
     state: restarted
+    daemon-reload: true
   when:
     - logstash_enable | bool
     - not logstash_freshstart.changed | bool
@@ -12,4 +13,5 @@
   ansible.builtin.service:
     name: logstash
     state: restarted
+    daemon-reload: true
   when: not logstash_config_autoreload and logstash_enable | bool


### PR DESCRIPTION
Reload unit files when restart Logstash via handler. We're running the handler for upgrades of the package, not only when changing configuration.

This might make reloads a bit slower but it seems to be the only chance to deal with changes in the Logstash unit file. We're not managing this file with the collection, so changing it manually is fine.

If someone does, we need to reload the unit file.

We *could* introduce a separate handler. One for upgrades of the package that does the daemon reload and another without reload for regular configuration changes. @frankhetterich @afeefghannam89 @martialblog what do you think? I went for one handler which does it all but that's just a suggestion so far.

Thank you, @frankhetterich for the bug report and the suggested fix.

fixes #342