### PR TITLE
Fix/schedule for kics

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -14,6 +14,8 @@ on:
           - debug
   pull_request:
   merge_group:
+  schedule:
+    - cron: '15 6 * * 4'
 jobs:
   kics:
     runs-on: ubuntu-latest

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -14,6 +14,8 @@ on:
           - debug
   pull_request:
   push:
+    branches:
+      - 'main'
   merge_group:
   schedule:
     - cron: '15 6 * * 4'

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+  push:
   merge_group:
   schedule:
     - cron: '15 6 * * 4'


### PR DESCRIPTION
Introduce 2 new incidents that will trigger a KICS (security scan) run:

* Weekly scheduled by cron
* On every `push`. We can rework that later. But it should be the fastest way of getting results into https://github.com/NETWAYS/ansible-collection-elasticstack/security right now. Which will help with assigning tasks.

This will fix the fact that KICS only runs on Pull Requests but does not work as code scanning utility the way GitHub means it.