### PR TITLE
Replace generic password with random one in Molecule

### DIFF
--- a/molecule/elasticsearch_test_modules/converge.yml
+++ b/molecule/elasticsearch_test_modules/converge.yml
@@ -50,7 +50,7 @@
       netways.elasticstack.elasticsearch_user:
         name: new-user1
         fullname: New User
-        password: changeMe123!
+        password: "{{ lookup('community.general.random_string', length=12, min_lower=1, min_upper=1, min_numeric=1, min_special=1, override_special='-_=!') }}"
         email: new@user.de
         roles:
           - new-role1


### PR DESCRIPTION
I know, this password is only used in Molecule. But maybe this can be that start to replace all the generic passwords we have with more secure, random ones.

After all, @pdolinic suggested that in the past already.