### PR TITLE
Add exception to KICS for http in non-security scenario

### DIFF
--- a/molecule/elasticsearch_no-security/verify.yml
+++ b/molecule/elasticsearch_no-security/verify.yml
@@ -26,6 +26,7 @@
 
     - name: Node check
       ansible.builtin.uri:
+# kics-scan ignore-line
         url: http://localhost:{{ elasticstack_elasticsearch_http_port }}/_cat/nodes
         method: GET
         return_content: yes

--- a/molecule/elasticsearch_no-security/verify.yml
+++ b/molecule/elasticsearch_no-security/verify.yml
@@ -9,8 +9,10 @@
   tasks:
 
 # Remember, this is the no-security scenario. So no https
+# The comment below will create an exception for KICS security scan
     - name: Health check
       ansible.builtin.uri:
+# kics-scan ignore-line
         url: http://localhost:{{ elasticstack_elasticsearch_http_port }}/_cluster/health
         method: GET
         return_content: yes


### PR DESCRIPTION
We need to use `http` without `s` for certain scenarios. This commit will introduce an exception so KICS will not complain about it.