### PR TITLE
Fix YAML multiline config for package names

### DIFF
--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -2,7 +2,7 @@
 
 - name: Construct exact name of Auditbeat package
   ansible.builtin.set_fact:
-    beats_auditbeat_package: >
+    beats_auditbeat_package: >-
       {{
       'auditbeat' +
       (elasticstack_versionseparator +

--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -2,7 +2,7 @@
 
 - name: Construct exact name of Filebeat package
   ansible.builtin.set_fact:
-    beats_filebeat_package: >
+    beats_filebeat_package: >-
       {{
       'filebeat' +
       (elasticstack_versionseparator +

--- a/roles/beats/tasks/metricbeat.yml
+++ b/roles/beats/tasks/metricbeat.yml
@@ -2,7 +2,7 @@
 
 - name: Construct exact name of Metricbeat package
   ansible.builtin.set_fact:
-    beats_metricbeat_package: >
+    beats_metricbeat_package: >-
       {{
       'metricbeat' +
       (elasticstack_versionseparator +

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Construct exact name of Kibana package
   ansible.builtin.set_fact:
-    kibana_package: >
+    kibana_package: >-
       {{
       'kibana' +
       ('-oss' if elasticstack_variant == 'oss' else '') +

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -58,7 +58,7 @@
 
 - name: Construct exact name of Logstash package
   ansible.builtin.set_fact:
-    logstash_package: >
+    logstash_package: >-
       {{
       'logstash' +
       ('-oss' if elasticstack_variant == 'oss' else '') +
@@ -72,7 +72,7 @@
 
 - name: Construct exact name of Logstash package
   ansible.builtin.set_fact:
-    logstash_package: >
+    logstash_package: >-
       {{
       'logstash' +
       ('-oss' if elasticstack_variant == 'oss' else '') +


### PR DESCRIPTION
* Use '>-' instead of '>' for YAML multline when creating package names.

**Currently I can't reproduce the error that is shown in the issue. Since it's a simple fix I provided a PR anyway but we need to test this more before we merge it.**

The extra newline at the end of the string can cause JSON parsing errors as reported by @cbeaujoin-stellar .

This change will strip the newline character after the name

fixes #357