### PR TITLE
Fix package naming

### DIFF
--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -14,7 +14,6 @@
 - name: Install Auditbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -26,7 +25,6 @@
 - name: Install Auditbeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Auditbeat
   when:
@@ -36,7 +34,6 @@
 - name: Install Auditbeat - deb
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Auditbeat
   when:

--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -5,15 +5,16 @@
     beats_auditbeat_package: >
       {{
       'auditbeat' +
-      (elasticstack_versionseparator +
+      ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > )|
       replace(' ', '')
       }}
 
 - name: Install Auditbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -25,6 +26,7 @@
 - name: Install Auditbeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Auditbeat
   when:
@@ -34,6 +36,7 @@
 - name: Install Auditbeat - deb
   ansible.builtin.package:
     name: "{{ beats_auditbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Auditbeat
   when:

--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -7,7 +7,7 @@
       'auditbeat' +
       ((elasticstack_versionseparator +
       elasticstack_version |
-      string ) if (elasticstack_version is defined and elasticstack_version | length > )|
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)|
       replace(' ', '')
       }}
 

--- a/roles/beats/tasks/auditbeat.yml
+++ b/roles/beats/tasks/auditbeat.yml
@@ -7,7 +7,7 @@
       'auditbeat' +
       ((elasticstack_versionseparator +
       elasticstack_version |
-      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)|
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '')
       }}
 

--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -5,14 +5,15 @@
     beats_filebeat_package: >
       {{
       'filebeat' +
-      (elasticstack_versionseparator +
+      ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '') }}
 
 - name: Install Filebeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -24,6 +25,7 @@
 - name: Install Filebeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Filebeat
   when:
@@ -33,6 +35,7 @@
 - name: Install Filebeat - deb
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Filebeat
   when:

--- a/roles/beats/tasks/filebeat.yml
+++ b/roles/beats/tasks/filebeat.yml
@@ -13,7 +13,6 @@
 - name: Install Filebeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -25,7 +24,6 @@
 - name: Install Filebeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Filebeat
   when:
@@ -35,7 +33,6 @@
 - name: Install Filebeat - deb
   ansible.builtin.package:
     name: "{{ beats_filebeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Filebeat
   when:

--- a/roles/beats/tasks/metricbeat.yml
+++ b/roles/beats/tasks/metricbeat.yml
@@ -5,15 +5,16 @@
     beats_metricbeat_package: >
       {{
       'metricbeat' +
-      (elasticstack_versionseparator +
+       ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '')
       }}
 
 - name: Install Metricbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -25,6 +26,7 @@
 - name: Install Metricbeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Metricbeat
   when:
@@ -34,6 +36,7 @@
 - name: Install Metricbeat - deb
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Metricbeat
   when:

--- a/roles/beats/tasks/metricbeat.yml
+++ b/roles/beats/tasks/metricbeat.yml
@@ -14,7 +14,6 @@
 - name: Install Metricbeat - rpm - full stack
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{{ elasticstack_release }}.x'
   notify:
@@ -26,7 +25,6 @@
 - name: Install Metricbeat - rpm - standalone
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Metricbeat
   when:
@@ -36,7 +34,6 @@
 - name: Install Metricbeat - deb
   ansible.builtin.package:
     name: "{{ beats_metricbeat_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Metricbeat
   when:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -131,10 +131,9 @@
     elasticsearch_package: >
       {{
       'elasticsearch' +
-      ('-oss' if elasticstack_variant == 'oss' else '') +
-      (elasticstack_versionseparator +
+      ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '')
       }}
 
@@ -151,6 +150,7 @@
 - name: Install Elasticsearch - rpm - full stack
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   when:
@@ -160,6 +160,7 @@
 - name: Install Elasticsearch - rpm - standalone
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   when:
     - ansible_os_family == "RedHat"
     - not elasticstack_full_stack | bool
@@ -167,6 +168,7 @@
 - name: Install Elasticsearch - deb
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   when:
     - ansible_os_family == "Debian"
 

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -150,7 +150,6 @@
 - name: Install Elasticsearch - rpm - full stack
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   when:
@@ -160,7 +159,6 @@
 - name: Install Elasticsearch - rpm - standalone
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   when:
     - ansible_os_family == "RedHat"
     - not elasticstack_full_stack | bool
@@ -168,7 +166,6 @@
 - name: Install Elasticsearch - deb
   ansible.builtin.package:
     name: "{{ elasticsearch_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   when:
     - ansible_os_family == "Debian"
 

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -53,7 +53,6 @@
 - name: Install Kibana - rpm - full stack
   ansible.builtin.package:
     name: "{{ kibana_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   notify:
@@ -65,7 +64,6 @@
 - name: Install Kibana - rpm - standalone
   ansible.builtin.package:
     name: "{{ kibana_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Kibana
   when:
@@ -75,7 +73,6 @@
 - name: Install Kibana - deb
   ansible.builtin.package:
     name: "{{ kibana_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Kibana
   when:

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -45,14 +45,15 @@
       {{
       'kibana' +
       ('-oss' if elasticstack_variant == 'oss' else '') +
-      (elasticstack_versionseparator +
+      ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '') }}
 
 - name: Install Kibana - rpm - full stack
   ansible.builtin.package:
     name: "{{ kibana_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   notify:
@@ -64,6 +65,7 @@
 - name: Install Kibana - rpm - standalone
   ansible.builtin.package:
     name: "{{ kibana_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Kibana
   when:
@@ -73,6 +75,7 @@
 - name: Install Kibana - deb
   ansible.builtin.package:
     name: "{{ kibana_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Kibana
   when:

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -85,7 +85,6 @@
 - name: Install Logstash - rpm - full stack
   ansible.builtin.package:
     name: "{{ logstash_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   notify:
@@ -97,7 +96,6 @@
 - name: Install Logstash - rpm - standalone
   ansible.builtin.package:
     name: "{{ logstash_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Logstash
   when:
@@ -107,7 +105,6 @@
 - name: Install Logstash - deb
   ansible.builtin.package:
     name: "{{ logstash_package }}"
-    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Logstash
   when:

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -61,10 +61,9 @@
     logstash_package: >
       {{
       'logstash' +
-      ('-oss' if elasticstack_variant == 'oss' else '') +
-      (elasticstack_versionseparator +
+      ((elasticstack_versionseparator +
       elasticstack_version |
-      string if elasticstack_version is defined else '') |
+      string ) if (elasticstack_version is defined and elasticstack_version | length > 0)) |
       replace(' ', '')
       }}
   when:
@@ -76,11 +75,8 @@
       {{
       'logstash' +
       ('-oss' if elasticstack_variant == 'oss' else '') +
-      (elasticstack_versionseparator +
-      '1:' +
-      elasticstack_version +
-      '-1' |
-      string if elasticstack_version is defined else '') |
+      ((elasticstack_versionseparator + '1:' + elasticstack_version + '-1') 
+      if (elasticstack_version is defined and elasticstack_version | length > 0) else '') |
       replace(' ', '')
       }}
   when:
@@ -89,6 +85,7 @@
 - name: Install Logstash - rpm - full stack
   ansible.builtin.package:
     name: "{{ logstash_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
     enablerepo:
       - 'elastic-{% if elasticstack_variant == "oss" %}oss-{% endif %}{{ elasticstack_release }}.x'
   notify:
@@ -100,6 +97,7 @@
 - name: Install Logstash - rpm - standalone
   ansible.builtin.package:
     name: "{{ logstash_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Logstash
   when:
@@ -109,6 +107,7 @@
 - name: Install Logstash - deb
   ansible.builtin.package:
     name: "{{ logstash_package }}"
+    state: "{{ 'latest' if elasticstack_version is not defined or elasticstack_version | length == 0 else 'present' }}"
   notify:
     - Restart Logstash
   when:

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -75,7 +75,7 @@
       {{
       'logstash' +
       ('-oss' if elasticstack_variant == 'oss' else '') +
-      ((elasticstack_versionseparator + '1:' + elasticstack_version + '-1') 
+      ((elasticstack_versionseparator + '1:' + elasticstack_version + '-1')
       if (elasticstack_version is defined and elasticstack_version | length > 0) else '') |
       replace(' ', '')
       }}


### PR DESCRIPTION
Fixes:
The package name for the OSS version had a trailing "-" at the end.
The packages were not updated to the latest version when no version was provided.