### PR TITLE
Extend Molecule tests to different distros

### DIFF
--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -101,6 +101,11 @@ jobs:
       fail-fast: false
       matrix:
         python_version: [ 3.5.10, 3.6.15, 3.7.13, 3.8.16, 3.10.10 ]
+        distro:
+          - ubuntu2204
+          - ubuntu2404
+          - rockylinux8
+          - rockylinux9
 
     steps:
       - name: Check out code
@@ -123,8 +128,9 @@ jobs:
 
       - name: Test with ansible-playbook
         run: |
-          ansible-playbook molecule/plugins/converge.yml
+          molecule test -s plugins
         env:
+          MOLECULE_DISTRO: ${{ matrix.distro }}
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
 
@@ -140,6 +146,11 @@ jobs:
       fail-fast: false
       matrix:
         ansible_core_version: [ 2.11.12, 2.12.10, 2.13.8, 2.14.4 ]
+        distro:
+          - ubuntu2204
+          - ubuntu2404
+          - rockylinux8
+          - rockylinux9
 
     steps:
       - name: Check out code
@@ -162,8 +173,9 @@ jobs:
 
       - name: Test with ansible-playbook
         run: |
-          ansible-playbook molecule/plugins/converge.yml
+          molecule test -s plugins
         env:
+          MOLECULE_DISTRO: ${{ matrix.distro }}
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
 
@@ -179,6 +191,11 @@ jobs:
       fail-fast: false
       matrix:
         python_cryptography_version: [ 2.5, 3.0, 3.1, 3.2, 3.3, 3.4, 35.0.0, 36.0.0, 38.0.0, 40.0.1]
+        distro:
+          - ubuntu2204
+          - ubuntu2404
+          - rockylinux8
+          - rockylinux9
 
     steps:
       - name: Check out code
@@ -202,7 +219,8 @@ jobs:
 
       - name: Test with ansible-playbook
         run: |
-          ansible-playbook molecule/plugins/converge.yml
+          molecule test -s plugins
         env:
+          MOLECULE_DISTRO: ${{ matrix.distro }}
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/molecule/plugins/molecule.yml
+++ b/molecule/plugins/molecule.yml
@@ -1,0 +1,25 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: "elasticstack${ELASTIC_RELEASE}-cluster1-${MOLECULE_DISTRO}"
+    groups:
+      - beats
+      - logstash
+      - elasticsearch
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+
+  # Just enable temporarily. Sometimes it's useful, but most of the time it's
+  # overwhelming
+  #env:
+  #  ANSIBLE_VERBOSITY: 3
+verifier:
+  name: ansible


### PR DESCRIPTION
We can run our checks for plugins/modules on different distros. While we should not encounter problems on one distro we don't see another given the way how installation and testing is handling, this could help to be extra safe.

This is a draft and meant as a discussion point.