### PR TITLE
Pin version of Python elasticsearch client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You will need the following Ansible collections installed
 You will need these packages / libraries installed. Some very basic packages like `openssl` get handled by the collection if needed. The following list contains packages and libraries which only apply to special cases or need for you to decide on the installation method.
 
 * `passlib` Python library if you do not disable password hashing for logstash user and you want to use logstash role from this collection. It should be installed with pip on the Ansible controller.
+* `elasticsearch` Python module. Current versions are either compatible to Elasticsearch 9 or versions lower than 9. There seems to be no version that can serve both. So for now we install a version of the client lower than 9 but need to take care to install the right one when we make this collection compatible to Elastic Stack 9
 
 You may want the following Ansible roles installed. There other ways to achieve what they are doing but using them is easy and convenient.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ molecule
 molecule-plugins[docker]
 pytest
 passlib
-elasticsearch
+elasticsearch<9

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -45,7 +45,7 @@
     - name: Install Python Modules via pip
       ansible.builtin.pip:
         name:
-          - elasticsearch
+          - 'elasticsearch<9'
           - cryptography
       ignore_errors: true
       register: elasticstack_pip_installation
@@ -61,7 +61,7 @@
 - name: Install Python Modules via pip  - forced
   ansible.builtin.pip:
     name:
-      - elasticsearch
+      - 'elasticsearch<9'
       - cryptography
     break_system_packages: true
   ignore_errors: true


### PR DESCRIPTION
There seems to be no version of the Python `elasticsearch` client that is compatible to all versions. It's either version 9 or below 9. So for now we pin the version of the client to one that is compatible to versions below 9. We need to take care of that when supporting Elastic Stack 9.