### PR TITLE
Fix "when" in "debug"

### DIFF
--- a/roles/beats/tasks/beats-security.yml
+++ b/roles/beats/tasks/beats-security.yml
@@ -18,11 +18,13 @@
   when: beats_cert_expiration_date.skipped is not defined and not beats_cert_expiration_date.valid_at.check_period
 
 - name: Print the beats certificate renew message
-  ansible.builtin.debug:
-    msg: |
-      Your beats certificate will expire before {{ beats_cert_expiration_buffer }}.
-      Ansible will renew it.
   when: beats_cert_expiration_date.skipped is not defined and not beats_cert_expiration_date.valid_at.check_period
+  block:
+    - name: Print the beats certificate renew message
+      ansible.builtin.debug:
+        msg: |
+          Your beats certificate will expire before {{ beats_cert_expiration_buffer }}.
+          Ansible will renew it.
 
 - name: Backup beats certs then remove
   when: "'renew_beats_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags or beats_cert_will_expire_soon | bool"

--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -27,14 +27,16 @@
     elasticstack_ca_expiration_days | int <= elasticstack_ca_expiration_buffer | int
 
 - name: Print the ca renew message
-  ansible.builtin.debug:
-    msg: |
-      Your ca will expire in {{ elasticstack_ca_expiration_days }} days.
-      Ansible will renew it and all elastic stack certificates
   when: >
     inventory_hostname == elasticstack_ca_host and
     elasticstack_ca_expiration_days is defined and
     elasticstack_ca_expiration_days | int <= elasticstack_ca_expiration_buffer | int
+  block:
+    - name: Print the ca renew message
+      ansible.builtin.debug:
+        msg: |
+          Your ca will expire in {{ elasticstack_ca_expiration_days }} days.
+          Ansible will renew it and all elastic stack certificates
 
 - name: Stop Logstash
   ansible.builtin.service:
@@ -120,11 +122,13 @@
   when: elasticsearch_cert_expiration_days is defined and elasticsearch_cert_expiration_days | int <= elasticsearch_cert_expiration_buffer | int
 
 - name: Print the elasticsearch certificate renew message
-  ansible.builtin.debug:
-    msg: |
-      Your elasticsearch certificate will expire in {{ elasticsearch_cert_expiration_days }} days.
-      Ansible will renew it.
   when: elasticsearch_cert_expiration_days is defined and elasticsearch_cert_expiration_days | int <= elasticsearch_cert_expiration_buffer | int
+  block:
+    - name: Print the elasticsearch certificate renew message
+      ansible.builtin.debug:
+        msg: |
+          Your elasticsearch certificate will expire in {{ elasticsearch_cert_expiration_days }} days.
+          Ansible will renew it.
 
 - name: Backup elasticsearch certs on node then remove
   when: "'renew_es_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags or elasticsearch_cert_will_expire_soon | bool"

--- a/roles/kibana/tasks/kibana-security.yml
+++ b/roles/kibana/tasks/kibana-security.yml
@@ -23,11 +23,13 @@
   when: kibana_cert_expiration_days is defined and kibana_cert_expiration_days | int <= kibana_cert_expiration_buffer | int
 
 - name: Print the kibana certificate renew message
-  ansible.builtin.debug:
-    msg: |
-      Your kibana certificate will expire in {{ kibana_cert_expiration_days }} days.
-      Ansible will renew it.
   when: kibana_cert_expiration_days is defined and kibana_cert_expiration_days | int <= kibana_cert_expiration_buffer | int
+  block:
+    - name: Print the kibana certificate renew message
+      ansible.builtin.debug:
+        msg: |
+          Your kibana certificate will expire in {{ kibana_cert_expiration_days }} days.
+          Ansible will renew it.
 
 - name: Backup kibana certs then remove
   when: "'renew_kibana_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags or kibana_cert_will_expire_soon | bool"

--- a/roles/logstash/tasks/logstash-security.yml
+++ b/roles/logstash/tasks/logstash-security.yml
@@ -23,11 +23,13 @@
   when: logstash_cert_expiration_days is defined and logstash_cert_expiration_days | int <= logstash_cert_expiration_buffer | int
 
 - name: Print the logstash certificate renew message
-  ansible.builtin.debug:
-    msg: |
-      Your logstash certificate will expire in {{ logstash_cert_expiration_days }} days.
-      Ansible will renew it.
   when: logstash_cert_expiration_days is defined and logstash_cert_expiration_days | int <= logstash_cert_expiration_buffer | int
+  block:
+    - name: Print the logstash certificate renew message
+      ansible.builtin.debug:
+        msg: |
+          Your logstash certificate will expire in {{ logstash_cert_expiration_days }} days.
+          Ansible will renew it.
 
 - name: Backup logstash certs then remove
   when: "'renew_logstash_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags"


### PR DESCRIPTION
We used `when` in `debug` tasks several times. As of now, this is identified as lint. So I took the freedom to move every `debug` that had a  `when` into a `block` using the `when`.