### PR TITLE
Remove cron schedule for KICS check.

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -17,8 +17,6 @@ on:
     branches:
       - 'main'
   merge_group:
-  schedule:
-    - cron: '15 6 * * 4'
 jobs:
   kics:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't really need this check scheduled. It should be sufficient checking PRs. And this is what we do.