### PR TITLE
Cancel outades pipeline runs

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -14,8 +14,12 @@ on:
           - debug
   pull_request:
   merge_group:
-  schedule:
-    - cron: '15 6 * * 4'
+
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   security_scan:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -18,6 +18,11 @@ on:
         required: true
         type: string
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -19,6 +19,11 @@ on:
       - 'molecule/plugins/**'
       - '.github/workflows/test_plugins.yml'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sanity_core_2_18_2_19:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/test_role_beats.yml'
       - 'molecule/beats_**'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_beats:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -18,6 +18,10 @@ on:
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_elasticsearch:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -18,6 +18,7 @@ on:
       - '.github/workflows/test_role_elasticsearch.yml'
       - 'molecule/elasticsearch_**'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/test_role_kibana.yml'
       - 'molecule/kibana_**'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_kibana:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/test_role_logstash.yml'
       - 'molecule/logstash_**'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_logstash:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -17,6 +17,11 @@ on:
       - '.github/workflows/test_role_repos.yml'
       - 'molecule/repos_**'
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_repos:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -23,6 +23,13 @@ on:
       - '.github/workflows/test_roles_pr.yml'
   merge_group:
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+# The merge queue is not affected because each merge attempt uses a new temporary branch with a unique name,
+# so github.ref is different each time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_collection:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
When a new push is made to a pull request, a new pipeline run starts. The already running one is no longer needed and only consumes resources.