### PR TITLE
GitHub cache

### DIFF
--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install test dependencies.
         run: |

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
 
       - name: Install Ansible
         run: |
@@ -86,6 +87,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
 
       - name: Install Ansible
         run: |
@@ -123,6 +125,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.11
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -172,12 +175,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "ansible-core>=2.19,<2.20"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |
@@ -217,6 +260,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.11
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
 
       - name: Install Ansible
         run: |
@@ -87,7 +86,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
 
       - name: Install Ansible
         run: |
@@ -125,7 +123,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.11
-          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -260,7 +257,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.11
-          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -56,12 +56,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -55,12 +55,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -56,12 +56,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -56,12 +56,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -59,12 +59,52 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -98,6 +98,19 @@ jobs:
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
 
+      - name: Debug - list existing apt caches
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "=== Looking for key: ${WANT_KEY} ==="
+          echo "=== All caches with prefix '${{ runner.os }}-apt-elastic-${{ matrix.release }}.' ==="
+          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+            | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
+          echo "=== Total cache count in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
+
       - name: Restore Elastic apt cache
         id: apt-cache
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
@@ -223,6 +236,19 @@ jobs:
       - name: Debug - latest Elasticsearch version
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Debug - list existing apt caches
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "=== Looking for key: ${WANT_KEY} ==="
+          echo "=== All caches with prefix '${{ runner.os }}-apt-elastic-${{ matrix.release }}.' ==="
+          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+            | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
+          echo "=== Total cache count in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
 
       - name: Restore Elastic apt cache
         id: apt-cache

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -85,11 +85,14 @@ jobs:
         run: |
           curl -fsSL \
             "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
-            -o /tmp/elastic-packages.gz
-          VERSION=$(zcat /tmp/elastic-packages.gz \
-            | awk '/^Package: elasticsearch$/{f=1} f && /^Version:/ && !v{v=$2; f=0} END{print v}')
-          rm -f /tmp/elastic-packages.gz
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            -o /tmp/Packages.gz
+
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug - latest Elasticsearch version
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
@@ -208,11 +211,14 @@ jobs:
         run: |
           curl -fsSL \
             "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
-            -o /tmp/elastic-packages.gz
-          VERSION=$(zcat /tmp/elastic-packages.gz \
-            | awk '/^Package: elasticsearch$/{f=1} f && /^Version:/ && !v{v=$2; f=0} END{print v}')
-          rm -f /tmp/elastic-packages.gz
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            -o /tmp/Packages.gz
+
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug - latest Elasticsearch version
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -23,6 +23,13 @@ on:
       - '.github/workflows/test_roles_pr.yml'
   merge_group:
 
+# Cancel outdated pipeline runs when a new push occurs in the pull request and a new pipeline starts.
+# The merge queue is not affected because each merge attempt uses a new temporary branch with a unique name,
+# so github.ref is different each time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_collection:
     if: github.event.pull_request.draft == false
@@ -61,12 +68,62 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          VERSION=$(curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            | zcat \
+            | awk '/^Package: elasticsearch$/{found=1} found && /^Version:/{print $2; exit}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        id: apt-cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache@v4
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Pre-download Elastic packages to apt cache
+        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/elastic-apt-cache
+          curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch \
+            | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
+          echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt stable main" \
+            | sudo tee /etc/apt/sources.list.d/elastic.list
+          sudo apt-get update -q
+          sudo apt-get install -y --download-only \
+            -o Dir::Cache::archives=/tmp/elastic-apt-cache \
+            elasticsearch logstash kibana filebeat
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |
@@ -116,12 +173,62 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "${{ matrix.ansible_version }}"
           python3 -m pip install -r requirements-test.txt
+
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          VERSION=$(curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            | zcat \
+            | awk '/^Package: elasticsearch$/{found=1} found && /^Version:/{print $2; exit}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Restore Elastic apt cache
+        id: apt-cache
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        uses: actions/cache@v4
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+
+      - name: Pre-download Elastic packages to apt cache
+        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/elastic-apt-cache
+          curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch \
+            | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
+          echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt stable main" \
+            | sudo tee /etc/apt/sources.list.d/elastic.list
+          sudo apt-get update -q
+          sudo apt-get install -y --download-only \
+            -o Dir::Cache::archives=/tmp/elastic-apt-cache \
+            elasticsearch logstash kibana filebeat
+
+      - name: Debug - apt cache contents
+        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"
+
+      - name: Ensure apt cache directory exists
+        run: mkdir -p /tmp/elastic-apt-cache
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -40,6 +40,8 @@ jobs:
   molecule_core_2_19:
     runs-on: ubuntu-latest
     needs: lint_collection
+    permissions:
+      actions: write
 
     env:
       COLLECTION_NAMESPACE: netways
@@ -114,6 +116,20 @@ jobs:
             -o Dir::Cache::archives=/tmp/elastic-apt-cache \
             elasticsearch logstash kibana filebeat
 
+      - name: Delete outdated Elastic apt caches
+        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "Keeping cache: ${CURRENT_KEY}"
+          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+            | jq -r --arg current "${CURRENT_KEY}" '.actions_caches[] | select(.key != $current) | .id' \
+            | while read -r CACHE_ID; do
+                echo "Deleting outdated cache id=${CACHE_ID}"
+                gh api --method DELETE "repos/${{ github.repository }}/actions/caches/${CACHE_ID}"
+              done
+
       - name: Debug - apt cache contents
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: |
@@ -145,6 +161,8 @@ jobs:
   molecule_core_2_20:
     runs-on: ubuntu-latest
     needs: lint_collection
+    permissions:
+      actions: write
 
     env:
       COLLECTION_NAMESPACE: netways
@@ -218,6 +236,20 @@ jobs:
           sudo apt-get install -y --download-only \
             -o Dir::Cache::archives=/tmp/elastic-apt-cache \
             elasticsearch logstash kibana filebeat
+
+      - name: Delete outdated Elastic apt caches
+        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "Keeping cache: ${CURRENT_KEY}"
+          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+            | jq -r --arg current "${CURRENT_KEY}" '.actions_caches[] | select(.key != $current) | .id' \
+            | while read -r CACHE_ID; do
+                echo "Deleting outdated cache id=${CACHE_ID}"
+                gh api --method DELETE "repos/${{ github.repository }}/actions/caches/${CACHE_ID}"
+              done
 
       - name: Debug - apt cache contents
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -40,8 +40,6 @@ jobs:
   molecule_core_2_19:
     runs-on: ubuntu-latest
     needs: lint_collection
-    permissions:
-      actions: write
 
     env:
       COLLECTION_NAMESPACE: netways
@@ -98,58 +96,14 @@ jobs:
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
 
-      - name: Debug - list existing apt caches
-        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
-          echo "=== Looking for key: ${WANT_KEY} ==="
-          echo "=== All caches in repo ==="
-          gh api "repos/${{ github.repository }}/actions/caches?per_page=100" \
-            | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
-          echo "=== Total cache count in repo ==="
-          gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
-
       - name: Restore Elastic apt cache
-        id: apt-cache
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/elastic-apt-cache
           key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
-          save-always: true
-
-      - name: Pre-download Elastic packages to apt cache
-        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p /tmp/elastic-apt-cache
-          curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch \
-            | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
-          echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt stable main" \
-            | sudo tee /etc/apt/sources.list.d/elastic.list
-          sudo apt-get update -q
-          sudo apt-get install -y --download-only \
-            -o Dir::Cache::archives=/tmp/elastic-apt-cache \
-            elasticsearch logstash kibana filebeat
-          sudo rm -f /tmp/elastic-apt-cache/lock
-          sudo rm -rf /tmp/elastic-apt-cache/partial
-
-      - name: Delete outdated Elastic apt caches
-        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CURRENT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
-          echo "Keeping cache: ${CURRENT_KEY}"
-          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
-            | jq -r --arg current "${CURRENT_KEY}" '.actions_caches[] | select(.key != $current) | .id' \
-            | while read -r CACHE_ID; do
-                echo "Deleting outdated cache id=${CACHE_ID}"
-                gh api --method DELETE "repos/${{ github.repository }}/actions/caches/${CACHE_ID}"
-              done
 
       - name: Debug - apt cache contents
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
@@ -182,8 +136,6 @@ jobs:
   molecule_core_2_20:
     runs-on: ubuntu-latest
     needs: lint_collection
-    permissions:
-      actions: write
 
     env:
       COLLECTION_NAMESPACE: netways
@@ -240,58 +192,14 @@ jobs:
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
 
-      - name: Debug - list existing apt caches
-        if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
-          echo "=== Looking for key: ${WANT_KEY} ==="
-          echo "=== All caches in repo ==="
-          gh api "repos/${{ github.repository }}/actions/caches?per_page=100" \
-            | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
-          echo "=== Total cache count in repo ==="
-          gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
-
       - name: Restore Elastic apt cache
-        id: apt-cache
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/elastic-apt-cache
           key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
-          save-always: true
-
-      - name: Pre-download Elastic packages to apt cache
-        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p /tmp/elastic-apt-cache
-          curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch \
-            | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
-          echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt stable main" \
-            | sudo tee /etc/apt/sources.list.d/elastic.list
-          sudo apt-get update -q
-          sudo apt-get install -y --download-only \
-            -o Dir::Cache::archives=/tmp/elastic-apt-cache \
-            elasticsearch logstash kibana filebeat
-          sudo rm -f /tmp/elastic-apt-cache/lock
-          sudo rm -rf /tmp/elastic-apt-cache/partial
-
-      - name: Delete outdated Elastic apt caches
-        if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CURRENT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
-          echo "Keeping cache: ${CURRENT_KEY}"
-          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
-            | jq -r --arg current "${CURRENT_KEY}" '.actions_caches[] | select(.key != $current) | .id' \
-            | while read -r CACHE_ID; do
-                echo "Deleting outdated cache id=${CACHE_ID}"
-                gh api --method DELETE "repos/${{ github.repository }}/actions/caches/${CACHE_ID}"
-              done
 
       - name: Debug - apt cache contents
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -83,10 +83,12 @@ jobs:
         id: elastic-version
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: |
-          VERSION=$(curl -fsSL \
+          curl -fsSL \
             "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
-            | zcat \
-            | awk '/^Package: elasticsearch$/{found=1} found && /^Version:/{print $2; exit}')
+            -o /tmp/elastic-packages.gz
+          VERSION=$(zcat /tmp/elastic-packages.gz \
+            | awk '/^Package: elasticsearch$/{f=1} f && /^Version:/ && !v{v=$2; f=0} END{print v}')
+          rm -f /tmp/elastic-packages.gz
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Debug - latest Elasticsearch version
@@ -204,10 +206,12 @@ jobs:
         id: elastic-version
         if: contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')
         run: |
-          VERSION=$(curl -fsSL \
+          curl -fsSL \
             "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
-            | zcat \
-            | awk '/^Package: elasticsearch$/{found=1} found && /^Version:/{print $2; exit}')
+            -o /tmp/elastic-packages.gz
+          VERSION=$(zcat /tmp/elastic-packages.gz \
+            | awk '/^Package: elasticsearch$/{f=1} f && /^Version:/ && !v{v=$2; f=0} END{print v}')
+          rm -f /tmp/elastic-packages.gz
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Debug - latest Elasticsearch version

--- a/.github/workflows/test_roles_pr.yml
+++ b/.github/workflows/test_roles_pr.yml
@@ -105,8 +105,8 @@ jobs:
         run: |
           WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
           echo "=== Looking for key: ${WANT_KEY} ==="
-          echo "=== All caches with prefix '${{ runner.os }}-apt-elastic-${{ matrix.release }}.' ==="
-          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+          echo "=== All caches in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=100" \
             | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
           echo "=== Total cache count in repo ==="
           gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
@@ -120,6 +120,7 @@ jobs:
           key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+          save-always: true
 
       - name: Pre-download Elastic packages to apt cache
         if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
@@ -133,6 +134,8 @@ jobs:
           sudo apt-get install -y --download-only \
             -o Dir::Cache::archives=/tmp/elastic-apt-cache \
             elasticsearch logstash kibana filebeat
+          sudo rm -f /tmp/elastic-apt-cache/lock
+          sudo rm -rf /tmp/elastic-apt-cache/partial
 
       - name: Delete outdated Elastic apt caches
         if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
@@ -244,8 +247,8 @@ jobs:
         run: |
           WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
           echo "=== Looking for key: ${WANT_KEY} ==="
-          echo "=== All caches with prefix '${{ runner.os }}-apt-elastic-${{ matrix.release }}.' ==="
-          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+          echo "=== All caches in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=100" \
             | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
           echo "=== Total cache count in repo ==="
           gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
@@ -259,6 +262,7 @@ jobs:
           key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+          save-always: true
 
       - name: Pre-download Elastic packages to apt cache
         if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'
@@ -272,6 +276,8 @@ jobs:
           sudo apt-get install -y --download-only \
             -o Dir::Cache::archives=/tmp/elastic-apt-cache \
             elasticsearch logstash kibana filebeat
+          sudo rm -f /tmp/elastic-apt-cache/lock
+          sudo rm -rf /tmp/elastic-apt-cache/partial
 
       - name: Delete outdated Elastic apt caches
         if: (contains(matrix.distro, 'ubuntu') || contains(matrix.distro, 'debian')) && steps.apt-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/warm_apt_cache.yml
+++ b/.github/workflows/warm_apt_cache.yml
@@ -1,0 +1,96 @@
+---
+name: Warm Elastic apt cache
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  warm_cache:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        release:
+          - 8
+
+    steps:
+      - name: Get latest Elasticsearch release
+        id: elastic-version
+        run: |
+          curl -fsSL \
+            "https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt/dists/stable/main/binary-amd64/Packages.gz" \
+            -o /tmp/Packages.gz
+          VERSION=$(zcat /tmp/Packages.gz \
+            | awk '$1=="Package:" && $2=="elasticsearch"{p=1} p && $1=="Version:"{print $2; p=0}' \
+            | sort -V \
+            | tail -n 1)
+          rm -f /tmp/Packages.gz
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Debug - latest Elasticsearch version
+        run: echo "Latest Elasticsearch ${{ matrix.release }}.x = ${{ steps.elastic-version.outputs.version }}"
+
+      - name: Debug - list existing apt caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WANT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "=== Looking for key: ${WANT_KEY} ==="
+          echo "=== All caches in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=100" \
+            | jq -r '.actions_caches[] | "\(.key)  size=\(.size_in_bytes)  created=\(.created_at)"'
+          echo "=== Total cache count in repo ==="
+          gh api "repos/${{ github.repository }}/actions/caches?per_page=1" | jq '.total_count'
+
+      - name: Restore Elastic apt cache
+        id: apt-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/elastic-apt-cache
+          key: ${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-apt-elastic-${{ matrix.release }}.
+          save-always: true
+
+      - name: Pre-download Elastic packages to apt cache
+        if: steps.apt-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/elastic-apt-cache
+          curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch \
+            | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
+          echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/${{ matrix.release }}.x/apt stable main" \
+            | sudo tee /etc/apt/sources.list.d/elastic.list
+          sudo apt-get update -q
+          sudo apt-get install -y --download-only \
+            -o Dir::Cache::archives=/tmp/elastic-apt-cache \
+            elasticsearch logstash kibana filebeat
+          sudo rm -f /tmp/elastic-apt-cache/lock
+          sudo rm -rf /tmp/elastic-apt-cache/partial
+
+      - name: Delete outdated Elastic apt caches
+        if: steps.apt-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_KEY="${{ runner.os }}-apt-elastic-${{ steps.elastic-version.outputs.version }}"
+          echo "Keeping cache: ${CURRENT_KEY}"
+          gh api "repos/${{ github.repository }}/actions/caches?key=${{ runner.os }}-apt-elastic-${{ matrix.release }}.&per_page=100" \
+            | jq -r --arg current "${CURRENT_KEY}" '.actions_caches[] | select(.key != $current) | .id' \
+            | while read -r CACHE_ID; do
+                echo "Deleting outdated cache id=${CACHE_ID}"
+                gh api --method DELETE "repos/${{ github.repository }}/actions/caches/${CACHE_ID}"
+              done
+
+      - name: Debug - apt cache contents
+        run: |
+          echo "=== /tmp/elastic-apt-cache/ ==="
+          ls -lh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(empty or does not exist)"
+          echo "=== Total size ==="
+          du -sh /tmp/elastic-apt-cache/ 2>/dev/null || echo "(n/a)"

--- a/molecule/beats_default/molecule.yml
+++ b/molecule/beats_default/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/beats_default/prepare.yml
+++ b/molecule/beats_default/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/beats_extended/molecule.yml
+++ b/molecule/beats_extended/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/beats_extended/prepare.yml
+++ b/molecule/beats_extended/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/elasticsearch_default/molecule.yml
+++ b/molecule/elasticsearch_default/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -23,6 +24,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/elasticsearch_default/prepare.yml
+++ b/molecule/elasticsearch_default/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/elasticsearch_roles_calculation/molecule.yml
+++ b/molecule/elasticsearch_roles_calculation/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -23,6 +24,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -33,6 +35,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/elasticsearch_roles_calculation/prepare.yml
+++ b/molecule/elasticsearch_roles_calculation/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Refresh apt cache
       ansible.builtin.apt:
         update_cache: yes

--- a/molecule/elasticstack_default/molecule.yml
+++ b/molecule/elasticstack_default/molecule.yml
@@ -16,7 +16,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - /tmp/elastic-apt-cache:/var/cache/apt/archives:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -29,7 +29,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - /tmp/elastic-apt-cache:/var/cache/apt/archives:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/elasticstack_default/molecule.yml
+++ b/molecule/elasticstack_default/molecule.yml
@@ -16,6 +16,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/var/cache/apt/archives:rw
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -28,6 +29,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/var/cache/apt/archives:rw
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/elasticstack_default/prepare.yml
+++ b/molecule/elasticstack_default/prepare.yml
@@ -21,6 +21,11 @@
         enabled: yes
       when: ansible_os_family == "RedHat"
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/kibana_default/molecule.yml
+++ b/molecule/kibana_default/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/kibana_default/prepare.yml
+++ b/molecule/kibana_default/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages needed for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/logstash_pinned_version/molecule.yml
+++ b/molecule/logstash_pinned_version/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/logstash_pinned_version/prepare.yml
+++ b/molecule/logstash_pinned_version/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/logstash_pipelines/molecule.yml
+++ b/molecule/logstash_pipelines/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/logstash_pipelines/prepare.yml
+++ b/molecule/logstash_pipelines/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/plugins/molecule.yml
+++ b/molecule/plugins/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/plugins/prepare.yml
+++ b/molecule/plugins/prepare.yml
@@ -6,6 +6,11 @@
       ansible.builtin.debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install packages for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/repos_default/molecule.yml
+++ b/molecule/repos_default/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/repos_default/prepare.yml
+++ b/molecule/repos_default/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install requirements for Debian
       ansible.builtin.apt:
         name:

--- a/molecule/repos_oss/molecule.yml
+++ b/molecule/repos_oss/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /tmp/elastic-apt-cache:/opt/elastic-apt-cache:ro
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/repos_oss/prepare.yml
+++ b/molecule/repos_oss/prepare.yml
@@ -6,6 +6,11 @@
       debug:
         var: ansible_facts.discovered_interpreter_python
 
+    - name: Populate apt cache from runner pre-downloaded packages
+      ansible.builtin.shell: |
+        cp /opt/elastic-apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      when: ansible_os_family == "Debian"
+
     - name: Install requirements for Debian
       ansible.builtin.apt:
         name:


### PR DESCRIPTION
- Add warm_apt_cache.yml. A Dedicated workflow that pre-downloads Elastic apt packages to the GitHub Actions cache (triggered on push to main, nightly, and manually)
- All test workflows restore the apt cache before running molecule. The version-based cache key updates automatically on new Elastic releases
- Add pip caching (actions/setup-python cache: 'pip') to all workflows
- Mount cached packages into molecule Docker containers via read-only volume; copy .deb files into apt archives in prepare.yml
- Fix #92