### PR TITLE
Fix Debian ansible_distribution_major_version numeric comparison

### DIFF
--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -10,7 +10,7 @@
   ansible.builtin.apt_key:
     url: "{{ elasticstack_repo_key }}"
     state: absent
-  when: ansible_distribution_major_version <= "12"
+  when: (ansible_distribution_major_version | int) <= 12
 
 # NOTE: Workaround for older ansible-core versions combined with Python 3.12 on managed nodes (e.g. Ubuntu 24.04),
 # where ansible.builtin.get_url may fail with HTTPSConnection/cert_file related errors. We intentionally use curl via


### PR DESCRIPTION
This change fixes a type comparison issue in the Ansible condition. Previously, ansible_distribution_major_version was compared as a string, which could lead to incorrect lexical comparisons. The update explicitly converts it to an integer using | int, ensuring a proper numeric comparison when checking if the version is less than or equal to 12.