### PR TITLE
feat: declare minimum ansible-core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ collections:
 
 ### Requirements
 
-This collection requires **ansible-core 2.18** or newer, which needs Python 3.11+ on the Ansible control node.
+On the Ansible control node:
+* `Ansible-Core >=2.18.0`
+* `Python >=3.11.0`
 
 You will need the following Ansible collections installed
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ collections:
 
 ### Requirements
 
+This collection requires **ansible-core 2.18** or newer, which needs Python 3.11+ on the Ansible control node.
+
 You will need the following Ansible collections installed
 
 * `community.general` (probably already present)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.18.0"


### PR DESCRIPTION
Add meta/runtime.yml with requires_ansible (>=2.18.0) and note the requirement in the README (ansible-core 2.18 needs Python 3.11+ on the control node). 
Closes #435