### PR TITLE
logstash: make redis host and TLS configurable for simple pipelines

### DIFF
--- a/roles/logstash/README.md
+++ b/roles/logstash/README.md
@@ -96,6 +96,12 @@ Run only parts of the role with `--tags`:
 | `logstash_redis_input_host` | `str` | `"localhost"` | — | Redis host that simple pipeline inputs (and the default forwarder input) read from. |
 | `logstash_redis_output_host` | `str` | `"localhost"` | — | Redis host that simple pipeline outputs (and the default input pipeline) write to. |
 | `logstash_redis_tls` | `bool` | `false` | — | Enable TLS on the simple Redis inputs/outputs (`ssl`/`ssl_enabled`). |
+| `logstash_redis_ssl_certificate` | `str` | N/A | — | Path to the SSL certificate for the Redis outputs (the redis output plugin only; the input plugin has no such option). Rendered only when logstash_redis_tls is true. |
+| `logstash_redis_ssl_key` | `str` | N/A | — | Path to the SSL key for the Redis outputs. Rendered only when logstash_redis_tls is true. |
+| `logstash_redis_ssl_key_passphrase` | `str` | N/A | — | Passphrase for logstash_redis_ssl_key. Rendered only when logstash_redis_tls is true. |
+| `logstash_redis_ssl_certificate_authorities` | `list` of `str` | N/A | — | List of CA certificate paths used to verify the Redis server on the Redis outputs. Rendered only when logstash_redis_tls is true. |
+| `logstash_redis_ssl_supported_protocols` | `str` | N/A | — | TLS protocol version accepted on the Redis outputs (for example "TLSv1.3"). Rendered only when logstash_redis_tls is true. |
+| `logstash_redis_ssl_verification_mode` | `str` | N/A | — | Certificate verification mode for the Redis outputs ("full" or "none"). Rendered only when logstash_redis_tls is true. |
 | `logstash_elasticsearch` | `list` of `str` | N/A | — | Elasticsearch hosts for the default output. Defaults to the nodes from the elasticsearch group, or localhost when used standalone. |
 | `logstash_validate_after_inactivity` | `str` | `"300"` | — | Seconds Logstash waits before validating a previously idle connection to Elasticsearch. |
 | `logstash_sniffing` | `bool` | `false` | — | Enable sniffing for additional Elasticsearch nodes. |

--- a/roles/logstash/README.md
+++ b/roles/logstash/README.md
@@ -93,6 +93,9 @@ Run only parts of the role with `--tags`:
 | `logstash_forwarder_queue_type` | `str` | `"memory"` | `memory`, `persisted` | Queue type for the default Elasticsearch forwarder pipeline. Use "persisted" for an on-disk persistent queue. |
 | `logstash_forwarder_queue_max_bytes` | `str` | `"1gb"` | — | Maximum queue size for the default Elasticsearch forwarder pipeline. |
 | `logstash_redis_password` | `str` | N/A | — | Password used when the simple inputs/outputs connect to Redis. Unset by default. |
+| `logstash_redis_input_host` | `str` | `"localhost"` | — | Redis host that simple pipeline inputs (and the default forwarder input) read from. |
+| `logstash_redis_output_host` | `str` | `"localhost"` | — | Redis host that simple pipeline outputs (and the default input pipeline) write to. |
+| `logstash_redis_tls` | `bool` | `false` | — | Enable TLS on the simple Redis inputs/outputs (`ssl`/`ssl_enabled`). |
 | `logstash_elasticsearch` | `list` of `str` | N/A | — | Elasticsearch hosts for the default output. Defaults to the nodes from the elasticsearch group, or localhost when used standalone. |
 | `logstash_validate_after_inactivity` | `str` | `"300"` | — | Seconds Logstash waits before validating a previously idle connection to Elasticsearch. |
 | `logstash_sniffing` | `bool` | `false` | — | Enable sniffing for additional Elasticsearch nodes. |

--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -43,6 +43,12 @@ logstash_input_queue_type: memory
 logstash_input_queue_max_bytes: 1gb
 logstash_forwarder_queue_type: memory
 logstash_forwarder_queue_max_bytes: 1gb
+
+# redis connection for simple pipeline inputs/outputs
+logstash_redis_input_host: localhost
+logstash_redis_output_host: localhost
+logstash_redis_tls: false
+
 logstash_sniffing: false
 
 # logstash role / user

--- a/roles/logstash/meta/argument_specs.yml
+++ b/roles/logstash/meta/argument_specs.yml
@@ -256,17 +256,17 @@ argument_specs:
       logstash_redis_input_host:
         type: str
         default: localhost
-        description: Redis host that the simple pipeline inputs connect to.
+        description: Redis host that simple pipeline inputs (and the default forwarder input) read from.
 
       logstash_redis_output_host:
         type: str
         default: localhost
-        description: Redis host that the simple pipeline outputs connect to.
+        description: Redis host that simple pipeline outputs (and the default input pipeline) write to.
 
       logstash_redis_tls:
         type: bool
         default: false
-        description: Whether the simple pipeline inputs/outputs use TLS to connect to Redis.
+        description: Enable TLS on the simple Redis inputs/outputs (`ssl`/`ssl_enabled`).
 
       # ----- Elasticsearch connection / output -----
       logstash_elasticsearch:

--- a/roles/logstash/meta/argument_specs.yml
+++ b/roles/logstash/meta/argument_specs.yml
@@ -253,6 +253,21 @@ argument_specs:
         type: str
         description: Password used when the simple inputs/outputs connect to Redis. Unset by default.
 
+      logstash_redis_input_host:
+        type: str
+        default: localhost
+        description: Redis host that the simple pipeline inputs connect to.
+
+      logstash_redis_output_host:
+        type: str
+        default: localhost
+        description: Redis host that the simple pipeline outputs connect to.
+
+      logstash_redis_tls:
+        type: bool
+        default: false
+        description: Whether the simple pipeline inputs/outputs use TLS to connect to Redis.
+
       # ----- Elasticsearch connection / output -----
       logstash_elasticsearch:
         type: list

--- a/roles/logstash/meta/argument_specs.yml
+++ b/roles/logstash/meta/argument_specs.yml
@@ -268,6 +268,44 @@ argument_specs:
         default: false
         description: Enable TLS on the simple Redis inputs/outputs (`ssl`/`ssl_enabled`).
 
+      logstash_redis_ssl_certificate:
+        type: str
+        description: >-
+          Path to the SSL certificate for the Redis outputs (the redis output
+          plugin only; the input plugin has no such option). Rendered only when
+          logstash_redis_tls is true.
+
+      logstash_redis_ssl_key:
+        type: str
+        description: >-
+          Path to the SSL key for the Redis outputs. Rendered only when
+          logstash_redis_tls is true.
+
+      logstash_redis_ssl_key_passphrase:
+        type: str
+        description: >-
+          Passphrase for logstash_redis_ssl_key. Rendered only when
+          logstash_redis_tls is true.
+
+      logstash_redis_ssl_certificate_authorities:
+        type: list
+        elements: str
+        description: >-
+          List of CA certificate paths used to verify the Redis server on the
+          Redis outputs. Rendered only when logstash_redis_tls is true.
+
+      logstash_redis_ssl_supported_protocols:
+        type: str
+        description: >-
+          TLS protocol version accepted on the Redis outputs (for example
+          "TLSv1.3"). Rendered only when logstash_redis_tls is true.
+
+      logstash_redis_ssl_verification_mode:
+        type: str
+        description: >-
+          Certificate verification mode for the Redis outputs ("full" or
+          "none"). Rendered only when logstash_redis_tls is true.
+
       # ----- Elasticsearch connection / output -----
       logstash_elasticsearch:
         type: list

--- a/roles/logstash/templates/redis-input.conf.j2
+++ b/roles/logstash/templates/redis-input.conf.j2
@@ -1,6 +1,9 @@
 input {
   redis {
-    host => "localhost"
+    host => "{{ logstash_redis_input_host }}"
+{% if logstash_redis_tls | bool %}
+    ssl => true
+{% endif %}
     data_type => "list"
     key => "forwarder"
 {% if logstash_redis_password is defined %}

--- a/roles/logstash/templates/redis-output.conf.j2
+++ b/roles/logstash/templates/redis-output.conf.j2
@@ -10,7 +10,10 @@ filter {
 {% endif %}
 output {
   redis {
-    host => "localhost"
+    host => "{{ logstash_redis_output_host }}"
+{% if logstash_redis_tls | bool %}
+    ssl_enabled => true
+{% endif %}
     data_type => "list"
     key => "input"
 {% if logstash_beats_input_congestion is defined %}    congestion_threshold => {{ logstash_beats_input_congestion }}{% endif %}

--- a/roles/logstash/templates/redis-output.conf.j2
+++ b/roles/logstash/templates/redis-output.conf.j2
@@ -13,6 +13,24 @@ output {
     host => "{{ logstash_redis_output_host }}"
 {% if logstash_redis_tls | bool %}
     ssl_enabled => true
+{% if logstash_redis_ssl_certificate is defined %}
+    ssl_certificate => "{{ logstash_redis_ssl_certificate }}"
+{% endif %}
+{% if logstash_redis_ssl_key is defined %}
+    ssl_key => "{{ logstash_redis_ssl_key }}"
+{% endif %}
+{% if logstash_redis_ssl_key_passphrase is defined %}
+    ssl_key_passphrase => "{{ logstash_redis_ssl_key_passphrase }}"
+{% endif %}
+{% if logstash_redis_ssl_certificate_authorities is defined %}
+    ssl_certificate_authorities => [{% for ca in logstash_redis_ssl_certificate_authorities %}"{{ ca }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endif %}
+{% if logstash_redis_ssl_supported_protocols is defined %}
+    ssl_supported_protocols => "{{ logstash_redis_ssl_supported_protocols }}"
+{% endif %}
+{% if logstash_redis_ssl_verification_mode is defined %}
+    ssl_verification_mode => "{{ logstash_redis_ssl_verification_mode }}"
+{% endif %}
 {% endif %}
     data_type => "list"
     key => "input"

--- a/roles/logstash/templates/simple-input.conf.j2
+++ b/roles/logstash/templates/simple-input.conf.j2
@@ -3,7 +3,10 @@ input {
 
 # {{ input.name }} input
   redis {
-    host => "localhost"
+    host => "{{ logstash_redis_input_host }}"
+{% if logstash_redis_tls | bool %}
+    ssl => true
+{% endif %}
     data_type => "list"
     key => "{{ input.key }}"
 {% if logstash_redis_password is defined %}

--- a/roles/logstash/templates/simple-output.conf.j2
+++ b/roles/logstash/templates/simple-output.conf.j2
@@ -16,7 +16,10 @@ output {
 {% if not loop.first and pipelinename.exclusive | bool %}else {% endif %}{% if (not loop.last and pipelinename.exclusive | bool) or not pipelinename.exclusive %}if {% endif %}{% if output.condition is defined %}{{ output.condition }} {% endif %}{
 {% endif %}
   redis {
-    host => "localhost"
+    host => "{{ logstash_redis_output_host }}"
+{% if logstash_redis_tls | bool %}
+    ssl_enabled => true
+{% endif %}
     data_type => "list"
     key => "{{ output.key }}"
 {% if logstash_redis_password is defined %}

--- a/roles/logstash/templates/simple-output.conf.j2
+++ b/roles/logstash/templates/simple-output.conf.j2
@@ -19,6 +19,24 @@ output {
     host => "{{ logstash_redis_output_host }}"
 {% if logstash_redis_tls | bool %}
     ssl_enabled => true
+{% if logstash_redis_ssl_certificate is defined %}
+    ssl_certificate => "{{ logstash_redis_ssl_certificate }}"
+{% endif %}
+{% if logstash_redis_ssl_key is defined %}
+    ssl_key => "{{ logstash_redis_ssl_key }}"
+{% endif %}
+{% if logstash_redis_ssl_key_passphrase is defined %}
+    ssl_key_passphrase => "{{ logstash_redis_ssl_key_passphrase }}"
+{% endif %}
+{% if logstash_redis_ssl_certificate_authorities is defined %}
+    ssl_certificate_authorities => [{% for ca in logstash_redis_ssl_certificate_authorities %}"{{ ca }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endif %}
+{% if logstash_redis_ssl_supported_protocols is defined %}
+    ssl_supported_protocols => "{{ logstash_redis_ssl_supported_protocols }}"
+{% endif %}
+{% if logstash_redis_ssl_verification_mode is defined %}
+    ssl_verification_mode => "{{ logstash_redis_ssl_verification_mode }}"
+{% endif %}
 {% endif %}
     data_type => "list"
     key => "{{ output.key }}"


### PR DESCRIPTION
The simple input/output (and default redis) templates hardcoded host => localhost with no TLS option, so pipelines could only reach a co-located Redis in plaintext. Add logstash_redis_input_host, logstash_redis_output_host and logstash_redis_tls (defaults keep the previous behaviour: localhost, no TLS).