### PR TITLE
kibana: manage file logging with variables

### DIFF
--- a/roles/kibana/README.md
+++ b/roles/kibana/README.md
@@ -26,6 +26,31 @@ trust and the `kibana_system` credentials — using the Elasticsearch CA.
     - kibana
 ```
 
+By default Kibana only logs to the journal, readable with
+`journalctl -u kibana`. Set `kibana_manage_logging` to write a log file that
+Kibana rotates itself, no logrotate needed:
+
+```yaml
+- name: Install Kibana with file logging
+  hosts: kibana
+  collections:
+    - netways.elasticstack
+  vars:
+    kibana_manage_logging: true
+    kibana_logpath: /var/log/kibana
+    kibana_loglevel: info
+    kibana_logging_rotate_size: 100mb
+    kibana_logging_rotate_keep: 10
+  roles:
+    - repos
+    - kibana
+```
+
+This writes `/var/log/kibana/kibana.log` in a human readable layout and keeps
+ten rotated files. Set `kibana_logging_layout` to `json` when a log shipper
+reads the file, and `kibana_logging_console` to `false` to stop logging to the
+journal as well.
+
 ## Tags
 
 Run only parts of the role with `--tags`:
@@ -53,6 +78,16 @@ Run only parts of the role with `--tags`:
 | `kibana_cert_validity_period` | `int` | `1095` | — | Number of days the generated certificates are valid. |
 | `kibana_cert_expiration_buffer` | `int` | `30` | — | Renew the certificate when its remaining validity (in days) drops below this value. |
 | `kibana_cert_will_expire_soon` | `bool` | `false` | — | Set to true to force renewal of the Kibana certificate. Alternatively run the playbook with the renew_kibana_cert tag. |
+| `kibana_manage_logging` | `bool` | `false` | — | Manage Kibana's own logging configuration and write log files to disk. When disabled, Kibana keeps its default behaviour and only logs to the journal. |
+| `kibana_logpath` | `str` | `"/var/log/kibana"` | — | Directory for the Kibana log files. The role creates it for the kibana user when kibana_manage_logging is enabled. |
+| `kibana_logfile` | `str` | `"kibana.log"` | — | Name of the log file inside kibana_logpath. |
+| `kibana_loglevel` | `str` | `"info"` | `all`, `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `off` | Log level of the root logger (logging.root.level). |
+| `kibana_logging_layout` | `str` | `"pattern"` | `pattern`, `json` | Layout of the log file. Use "pattern" for human readable logs and "json" when the file is picked up by a log shipper. |
+| `kibana_logging_console` | `bool` | `true` | — | Keep logging to the console (and therefore the journal) in addition to the log file. Set to false to log to the file only. |
+| `kibana_logging_rotate_policy` | `str` | `"size-limit"` | `size-limit`, `time-interval` | Rotation policy of the log file. Kibana supports only one policy per appender, either by size (kibana_logging_rotate_size) or by time (kibana_logging_rotate_interval). |
+| `kibana_logging_rotate_size` | `str` | `"100mb"` | — | Size at which the log file is rotated. Only used when kibana_logging_rotate_policy is "size-limit". |
+| `kibana_logging_rotate_interval` | `str` | `"24h"` | — | Interval at which the log file is rotated. Only used when kibana_logging_rotate_policy is "time-interval". |
+| `kibana_logging_rotate_keep` | `int` | `10` | — | Number of rotated log files to keep (strategy max). |
 | `kibana_extra_config` | `str` | N/A | — | Extra configuration appended verbatim to kibana.yml (YAML). Unset by default. |
 | `kibana_freshstart` | `dict` | `{'changed': False}` | — | Internal state used by the role to detect a fresh install. Do not set manually. |
 

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -15,5 +15,16 @@ kibana_cert_will_expire_soon: false
 kibana_sniff_on_start: false
 kibana_sniff_on_connection_fault: false
 
+kibana_manage_logging: false
+kibana_logpath: /var/log/kibana
+kibana_logfile: kibana.log
+kibana_loglevel: info
+kibana_logging_layout: pattern
+kibana_logging_console: true
+kibana_logging_rotate_policy: size-limit
+kibana_logging_rotate_size: 100mb
+kibana_logging_rotate_interval: 24h
+kibana_logging_rotate_keep: 10
+
 kibana_freshstart:
   changed: false

--- a/roles/kibana/meta/argument_specs.yml
+++ b/roles/kibana/meta/argument_specs.yml
@@ -109,6 +109,88 @@ argument_specs:
           Set to true to force renewal of the Kibana certificate. Alternatively
           run the playbook with the renew_kibana_cert tag.
 
+      # ----- Logging -----
+      kibana_manage_logging:
+        type: bool
+        default: false
+        description: >-
+          Manage Kibana's own logging configuration and write log files to disk.
+          When disabled, Kibana keeps its default behaviour and only logs to
+          the journal.
+
+      kibana_logpath:
+        type: str
+        default: /var/log/kibana
+        description: >-
+          Directory for the Kibana log files. The role creates it for the kibana
+          user when kibana_manage_logging is enabled.
+
+      kibana_logfile:
+        type: str
+        default: kibana.log
+        description: Name of the log file inside kibana_logpath.
+
+      kibana_loglevel:
+        type: str
+        choices:
+          - all
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+          - fatal
+          - "off"
+        default: info
+        description: Log level of the root logger (logging.root.level).
+
+      kibana_logging_layout:
+        type: str
+        choices:
+          - pattern
+          - json
+        default: pattern
+        description: >-
+          Layout of the log file. Use "pattern" for human readable logs and
+          "json" when the file is picked up by a log shipper.
+
+      kibana_logging_console:
+        type: bool
+        default: true
+        description: >-
+          Keep logging to the console (and therefore the journal) in addition to
+          the log file. Set to false to log to the file only.
+
+      kibana_logging_rotate_policy:
+        type: str
+        choices:
+          - size-limit
+          - time-interval
+        default: size-limit
+        description: >-
+          Rotation policy of the log file. Kibana supports only one policy per
+          appender, either by size (kibana_logging_rotate_size) or by time
+          (kibana_logging_rotate_interval).
+
+      kibana_logging_rotate_size:
+        type: str
+        default: 100mb
+        description: >-
+          Size at which the log file is rotated. Only used when
+          kibana_logging_rotate_policy is "size-limit".
+
+      kibana_logging_rotate_interval:
+        type: str
+        default: 24h
+        description: >-
+          Interval at which the log file is rotated. Only used when
+          kibana_logging_rotate_policy is "time-interval".
+
+      kibana_logging_rotate_keep:
+        type: int
+        default: 10
+        description: Number of rotated log files to keep (strategy max).
+
       # ----- Extra configuration -----
       kibana_extra_config:
         type: str

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -94,6 +94,15 @@
     - renew_ca
     - renew_kibana_cert
 
+- name: Create directory for logging if file logging is activated
+  ansible.builtin.file:
+    path: "{{ kibana_logpath }}"
+    state: directory
+    owner: kibana
+    group: kibana
+    mode: 0750
+  when: kibana_manage_logging | bool
+
 - name: Configure Kibana
   ansible.builtin.template:
     src: kibana.yml.j2

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -31,6 +31,24 @@ server.ssl.certificate: "{{ kibana_tls_cert }}"
 server.ssl.key: "{{ kibana_tls_key }}"
 {% endif %}
 
+{% if kibana_manage_logging | bool %}
+logging.root.level: "{{ kibana_loglevel }}"
+logging.root.appenders: [{% if kibana_logging_console | bool %}default, {% endif %}file]
+logging.appenders.file.type: rolling-file
+logging.appenders.file.fileName: "{{ kibana_logpath }}/{{ kibana_logfile }}"
+logging.appenders.file.layout.type: {{ kibana_logging_layout }}
+logging.appenders.file.policy.type: {{ kibana_logging_rotate_policy }}
+{% if kibana_logging_rotate_policy == "size-limit" %}
+logging.appenders.file.policy.size: {{ kibana_logging_rotate_size }}
+{% else %}
+logging.appenders.file.policy.interval: {{ kibana_logging_rotate_interval }}
+logging.appenders.file.policy.modulate: true
+{% endif %}
+logging.appenders.file.strategy.type: numeric
+logging.appenders.file.strategy.pattern: ".%i"
+logging.appenders.file.strategy.max: {{ kibana_logging_rotate_keep }}
+{% endif %}
+
 {% if kibana_extra_config is defined %}
 {{ kibana_extra_config }}
 {% endif %}


### PR DESCRIPTION
Kibana previously only logged to the journal and its logging could only be configured through the verbatim kibana_extra_config passthrough.

Add kibana_manage_logging (off by default, so existing behaviour is kept) plus variables for path, file name, level, layout, console output and rotation. The settings are rendered as flat dotted keys, matching both the rest of kibana.yml.j2 and the style of Elastic's shipped config/kibana.yml.

Rotation is handled by Kibana's rolling-file appender, so no logrotate is needed. The role also creates the log directory for the kibana user, which the passthrough could not do.

Closes #142