### PR TITLE
elasticsearch: fix keystore restart notify and non-rolling upgrade

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-keystore.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-keystore.yml
@@ -19,7 +19,7 @@
       - bootstrap.password
     stdin: "{{ elasticsearch_bootstrap_pw }}"
   when: "'bootstrap.password' not in elasticsearch_keystore.stdout_lines"
-  changed_when: false
+  changed_when: true
   no_log: true
   notify:
     - Restart Elasticsearch
@@ -48,7 +48,7 @@
       - -x
       - xpack.security.http.ssl.keystore.secure_password
     stdin: "{{ elasticsearch_tls_key_passphrase }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_http_ssl_keystore_secure_password.stdout is undefined or elasticsearch_tls_key_passphrase != elasticsearch_http_ssl_keystore_secure_password.stdout
@@ -62,7 +62,7 @@
       - /usr/share/elasticsearch/bin/elasticsearch-keystore
       - remove
       - xpack.security.http.ssl.keystore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.http.ssl.keystore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -93,7 +93,7 @@
       - -x
       - xpack.security.http.ssl.truststore.secure_password
     stdin: "{{ elasticsearch_tls_key_passphrase }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_http_ssl_truststore_secure_password.stdout is undefined or elasticsearch_tls_key_passphrase != elasticsearch_http_ssl_truststore_secure_password.stdout
@@ -107,7 +107,7 @@
       - /usr/share/elasticsearch/bin/elasticsearch-keystore
       - remove
       - xpack.security.http.ssl.truststore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.http.ssl.truststore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -138,7 +138,7 @@
       - -x
       - xpack.security.transport.ssl.keystore.secure_password
     stdin: "{{ elasticsearch_tls_key_passphrase }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_transport_ssl_keystore_secure_password.stdout is undefined or elasticsearch_tls_key_passphrase != elasticsearch_transport_ssl_keystore_secure_password.stdout
@@ -152,7 +152,7 @@
       - /usr/share/elasticsearch/bin/elasticsearch-keystore
       - remove
       - xpack.security.transport.ssl.keystore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.transport.ssl.keystore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -183,7 +183,7 @@
       - -x
       - xpack.security.transport.ssl.truststore.secure_password
     stdin: "{{ elasticsearch_tls_key_passphrase }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_transport_ssl_truststore_secure_password.stdout is undefined or elasticsearch_tls_key_passphrase != elasticsearch_transport_ssl_truststore_secure_password.stdout
@@ -197,7 +197,7 @@
       - /usr/share/elasticsearch/bin/elasticsearch-keystore
       - remove
       - xpack.security.transport.ssl.truststore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.transport.ssl.truststore.secure_password' in elasticsearch_keystore.stdout_lines"

--- a/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
@@ -80,7 +80,7 @@
         body: '{ "persistent": { "cluster.routing.allocation.enable": null }}'
         body_format: json
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
       register: response
       # next line is boolean not string, so no quotes around true
@@ -96,7 +96,7 @@
         url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health"
         method: GET
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
       register: response
       until: "response.json.status == 'green'"
@@ -111,7 +111,7 @@
         body: '{ "persistent": { "cluster.routing.allocation.enable": "none" }}'
         body_format: json
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
 
     - name: Stop non essential indexing to speed up shard recovery
@@ -119,7 +119,7 @@
         url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_flush"
         method: POST
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
       failed_when: false
 
@@ -176,7 +176,7 @@
         if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
         curl
         -k
-        -u elastic:{{ elasticstack_password.stdout }}
+        -u elastic:{{ __elasticstack_password }}
         -s
         -m 2
         '{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cat/nodes?h=name'
@@ -196,7 +196,7 @@
         body: '{ "persistent": { "cluster.routing.allocation.enable": null }}'
         body_format: json
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
       register: response
       # next line is boolean not string, so no quotes around true
@@ -210,7 +210,7 @@
         url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health"
         method: GET
         user: elastic
-        password: "{{ elasticstack_password.stdout }}"
+        password: "{{ __elasticstack_password }}"
         validate_certs: no
       register: response
       until: "response.json.status == 'yellow' or response.json.status == 'green'"

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -135,7 +135,7 @@
     - "hostvars[item].inventory_hostname == inventory_hostname"
     - elasticstack_version is defined
     - ansible_facts.packages['elasticsearch'][0].version is defined
-    - elasticstack_password.stdout is defined
+    - __elasticstack_password is defined
     - elasticstack_version is version( ansible_facts.packages['elasticsearch'][0].version, '>')
 
 - name: Install Elasticsearch - rpm - full stack
@@ -147,6 +147,8 @@
   when:
     - ansible_os_family == "RedHat"
     - elasticstack_full_stack | bool
+    # fresh install only, an upgrade goes through elasticsearch-rolling-upgrade.yml
+    - "'elasticsearch' not in ansible_facts.packages"
 
 - name: Install Elasticsearch - rpm - standalone
   ansible.builtin.package:
@@ -155,6 +157,8 @@
   when:
     - ansible_os_family == "RedHat"
     - not elasticstack_full_stack | bool
+    # fresh install only, an upgrade goes through elasticsearch-rolling-upgrade.yml
+    - "'elasticsearch' not in ansible_facts.packages"
 
 - name: Install Elasticsearch - deb
   ansible.builtin.package:
@@ -162,6 +166,8 @@
     state: present
   when:
     - ansible_os_family == "Debian"
+    # fresh install only, an upgrade goes through elasticsearch-rolling-upgrade.yml
+    - "'elasticsearch' not in ansible_facts.packages"
 
 - name: Configure Elasticsearch
   ansible.builtin.template:

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -1,4 +1,3 @@
-# test
 {{ ansible_managed | comment }}
 
 node.name: "{{ elasticsearch_nodename }}"

--- a/roles/elasticstack/tasks/elasticstack-passwords.yml
+++ b/roles/elasticstack/tasks/elasticstack-passwords.yml
@@ -23,3 +23,4 @@
   ansible.builtin.set_fact:
     __elasticstack_password: "{{ __elasticstack_password_fetch.stdout }}"
   when: __elasticstack_password_fetch.stdout is defined
+  no_log: "{{ elasticstack_no_log }}"

--- a/roles/elasticstack/tasks/elasticstack-passwords.yml
+++ b/roles/elasticstack/tasks/elasticstack-passwords.yml
@@ -4,6 +4,7 @@
   ansible.builtin.stat:
     path: "{{ elasticstack_initial_passwords }}"
   delegate_to: "{{ elasticstack_ca_host | default(omit, true) }}"
+  run_once: true
   register: elasticsearch_passwords_file
 
 - name: Fetch Elastic password # noqa: risky-shell-pipe
@@ -11,8 +12,14 @@
     if test -n "$(ps -p $$ | grep bash)"; then set -o pipefail; fi;
     grep "PASSWORD elastic" {{ elasticstack_initial_passwords }} |
     awk {' print $4 '}
-  register: elasticstack_password
+  register: __elasticstack_password_fetch
+  run_once: true
   changed_when: false
   no_log: "{{ elasticstack_no_log }}"
   delegate_to: "{{ elasticstack_ca_host | default(omit, true) }}"
   when: elasticsearch_passwords_file.stat.exists | bool
+
+- name: Persist the elastic password as a fact for all roles
+  ansible.builtin.set_fact:
+    __elasticstack_password: "{{ __elasticstack_password_fetch.stdout }}"
+  when: __elasticstack_password_fetch.stdout is defined

--- a/roles/elasticstack/tasks/main.yml
+++ b/roles/elasticstack/tasks/main.yml
@@ -10,7 +10,6 @@
 
     - name: Set versions for components
       ansible.builtin.import_tasks: elasticstack-versions.yml
-      when: elasticstack_full_stack | bool
 
     - name: Fetch passwords if passwords are initialized
       ansible.builtin.import_tasks: elasticstack-passwords.yml


### PR DESCRIPTION
Two separate bugs in the Elasticsearch upgrade and keystore paths, plus one leftover line.

### Keystore credentials never triggered a restart (#540)

The keystore tasks carried `changed_when: false`, which also kills the `notify`. Changing a
credential therefore updated the keystore but Elasticsearch kept running with the old value
until some unrelated task happened to restart it.

### A version bump upgraded all nodes at once (#546)

`Update Elasticsearch if needed` was skipped on every host, so raising `elasticstack_version`
fell through to the plain `package: state=present` tasks below it and every node was upgraded
and restarted together. Three changes:

* `elasticstack-passwords.yml` now persists the fetched elastic password with `set_fact`
  (`__elasticstack_password`), so it is in scope no matter which role runs first.
* `elasticstack-versions.yml` is no longer imported only for `elasticstack_full_stack`, so
  `package_facts` is always gathered and the installed-version comparison also works standalone.
* The three install tasks are limited to a fresh install
  (`'elasticsearch' not in ansible_facts.packages`). A version bump can now only take the
  rolling path, and a broken rolling upgrade fails visibly instead of silently upgrading
  everything.

Closes #540
Closes #546