### PR TITLE
GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,37 +1,69 @@
 name: Bug Report
-description: File a bug report
+description: Something in the collection behaves wrong or is broken
 title: "[Bug]: "
-labels: ["bug", "needs-triage"]
+labels: ["bug"]
 body:
   - type: checkboxes
-    id: terms
+    id: searched
     attributes:
-      label: Please try to fill out as much of the information below as you can. Thank you!
+      label: Before you start
       options:
-        - label: Yes, I've searched similar issues on GitHub and didn't find any.
+        - label: I searched the existing issues and did not find this one.
           required: true
-  - type: input
-    id: app_version
+
+  - type: dropdown
+    id: component
     attributes:
-      label: Which version contains the bug?
-      placeholder: 1.0.0
+      label: Component
+      description: Which part of the collection does this concern? Pick more than one if it applies.
+      multiple: true
+      options:
+        - elasticsearch
+        - kibana
+        - logstash
+        - beats (shared, or several beats at once)
+        - filebeat
+        - metricbeat
+        - auditbeat
+        - repos
+        - elasticstack (meta role, shared variables)
+        - plugins (cert_info, elasticsearch_role, elasticsearch_user)
+        - not sure, or affects the whole collection
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: A clear and concise description of what the bug is.
+      label: What happens
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+
   - type: textarea
     id: reproduce
     attributes:
-      label: To Reproduce
-      description: Describe how to reproduce the bug.
+      label: How to reproduce
+      description: The playbook, inventory and variables you used, and the steps you ran.
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant output
+      description: The failing task and its output. Run the play with -v if the message is unclear.
+      render: shell
+
   - type: textarea
     id: environment
     attributes:
-      label: Your Environment
-      description: Include as many relevant details about the environment you experienced the problem in.
+      label: Environment
       value: |
-        * Version (commit) used:
-        * Ansible version:
-        * Python version:
-        * Operating System and version:
+        * Collection version or commit:
+        * Elastic Stack version (elasticstack_version):
+        * ansible-core version:
+        * Python version on the controller:
+        * Target OS and version:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,15 +1,52 @@
 name: Feature Request
-description: Request a feature or enhancement
+description: Ask for a new capability or a new variable
 title: "[Feature]: "
-labels: ["feature", "needs-triage"]
+labels: ["feature"]
 body:
   - type: markdown
     attributes:
       value: |
-        Please try to fill out as much of the information below as you can. Thank you!
-        **Note:** If you want to sponsor new features, contact us at info@netways.de
-  - type: textarea
-    id: description
+        If you want to sponsor a feature, contact us at info@netways.de
+
+  - type: checkboxes
+    id: searched
     attributes:
-      label: Describe the feature request
-      description: Please provide a concise description of the feature. You can use markdown.
+      label: Before you start
+      options:
+        - label: I searched the existing issues and did not find this one.
+          required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the collection does this concern? Pick more than one if it applies.
+      multiple: true
+      options:
+        - elasticsearch
+        - kibana
+        - logstash
+        - beats (shared, or several beats at once)
+        - filebeat
+        - metricbeat
+        - auditbeat
+        - repos
+        - elasticstack (meta role, shared variables)
+        - plugins (cert_info, elasticsearch_role, elasticsearch_user)
+        - not sure, or affects the whole collection
+    validations:
+      required: true
+
+  - type: textarea
+    id: missing
+    attributes:
+      label: What is missing
+      description: What can you not do today, and why does the current behaviour not cover it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: How it could work
+      description: If you already have an idea - new variables, their defaults, the configuration they should produce.

--- a/.github/ISSUE_TEMPLATE/maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yaml
@@ -1,7 +1,6 @@
-name: Documentation
-description: Documentation is missing, wrong or unclear
-title: "[Documentation]: "
-labels: ["documentation"]
+name: Maintenance
+description: Internal work with no new capability for users - cleanup, refactoring, consistency, tests
+labels: ["quality"]
 body:
   - type: dropdown
     id: component
@@ -24,19 +23,23 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: where
-    attributes:
-      label: Where
-      description: Which file or page - for example the main README, a role README, meta/argument_specs.yml, or an example playbook.
-      placeholder: roles/elasticsearch/README.md
-    validations:
-      required: true
-
   - type: textarea
     id: change
     attributes:
       label: What should change
-      description: What is wrong or missing, and what should it say instead?
+      description: The current state, and what it should look like instead. Name the files or variables if you already know them.
     validations:
       required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: What goes wrong today, or what does the current shape make harder than it needs to be?
+
+  - type: checkboxes
+    id: breaking
+    attributes:
+      label: Impact
+      options:
+        - label: This changes existing behaviour, variable names or defaults, so users have to adapt.

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,10 +1,38 @@
 name: Question
-description: Ask a question
+description: Ask how something works or how to configure it
 title: "[Question]: "
 labels: ["question"]
 body:
-  - type: textarea
-    id: description
+  - type: dropdown
+    id: component
     attributes:
-      label: Ask a question
-      description: Please provide as much context as possible. You can use markdown.
+      label: Component
+      description: Which part of the collection does this concern? Pick more than one if it applies.
+      multiple: true
+      options:
+        - elasticsearch
+        - kibana
+        - logstash
+        - beats (shared, or several beats at once)
+        - filebeat
+        - metricbeat
+        - auditbeat
+        - repos
+        - elasticstack (meta role, shared variables)
+        - plugins (cert_info, elasticsearch_role, elasticsearch_user)
+        - not sure, or affects the whole collection
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Please add as much context as you can - the variables you set and what you are trying to achieve.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried already

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: netways
 name: elasticstack
-version: 1.0.0
+version: 0.1.0
 readme: README.md
 authors:
 - Afeef Ghannam <afeef.ghannam@netways.de>


### PR DESCRIPTION
## GitHub templates

The four existing forms had almost no required fields and did not say which part of the
collection an issue is about, so every new issue had to be classified by hand.

* Every form now has a required `Component` dropdown covering the roles, the single beats,
  `plugins/` and "affects the whole collection". It maps to the new `component:*` labels.
* `needs-triage` removed from the form labels - an issue without a `component:*` label now
  *is* the triage queue, so the label was a second signal for the same state.
* Bug report: description, reproduction and environment are required, output is rendered as a
  code block. The separate "which version" field is gone, it asked for a release number that
  does not exist yet; the commit now belongs in the environment block.
* Documentation: new required "Where" field, so a report points at a file instead of "somewhere
  in the docs".
* New `maintenance.yaml` for internal work with no user-facing capability - cleanup,
  refactoring, consistency, tests. Labels `quality` and asks whether the change is breaking.

## Collection version
Change the version in galaxy.yml to 0.1.0